### PR TITLE
Update desktop file build requirement

### DIFF
--- a/package/yast2-sudo.changes
+++ b/package/yast2-sudo.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jul 19 09:49:14 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Added "BuildRequires: update-desktop-files"
+- Related to the previous desktop file changes (fate#319035)
+- 4.2.1
+
+-------------------------------------------------------------------
 Fri May 31 12:40:44 UTC 2019 - Stasiek Michalski <hellcp@mailbox.org>
 
 - Add metainfo (fate#319035)

--- a/package/yast2-sudo.spec
+++ b/package/yast2-sudo.spec
@@ -18,7 +18,7 @@
 
 Name:           yast2-sudo
 Summary:        YaST2 - Sudo configuration
-Version:        4.2.0
+Version:        4.2.1
 Release:        0
 Url:            https://github.com/yast/yast-sudo
 Group:          System/YaST

--- a/package/yast2-sudo.spec
+++ b/package/yast2-sudo.spec
@@ -34,6 +34,7 @@ Requires:       yast2-ruby-bindings >= 1.0.0
 BuildRequires:  yast2 yast2-users
 BuildRequires:  yast2-devtools >= 4.2.2
 BuildRequires:  rubygem(yast-rake)
+BuildRequires:  update-desktop-files
 
 BuildArch:      noarch
 


### PR DESCRIPTION
> - The recent fix in YaST RPM macros now updates the desktop files
> - The `%suse_update_desktop_file` macro is defined in the `update-desktop-files` package
> - Without it the macro is not expanded and the shell treats `%` as a job control character and fails with error `fg: no job control`

---

Originally fixed by @lslezak in https://github.com/yast/yast-instserver/pull/45