### PR TITLE
WIP: Add a CFA model for handling the sudoers file

### DIFF
--- a/src/lib/cfa/sudoers.rb
+++ b/src/lib/cfa/sudoers.rb
@@ -1,0 +1,237 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "yast2/target_file"
+require "cfa/base_model"
+require "cfa/augeas_parser"
+require "cfa/matcher"
+require "cfa/placer"
+
+module CFA
+  # Model to handle users specifications in the /etc/sudoers file
+  #
+  # @example Loading specifications
+  #   file = Sudoers.new
+  #   file.load
+  #   file.current_user_specs
+  #
+  # @example Shortcut loading specificitions
+  #   Sudoers.load.users_specs
+  #
+  # @example Writing new specifications
+  #   file = Sudores.new
+  #   file.load
+  #   file.clean_users
+  #   file.add_user({ "user" => "yast", "host" => "ALL", "commands" => ["/sbin/yast2"] })
+  #   file.add_user({ "user" => "foo", "host" => "ALL", "commands" => ["ALL"], "tag" => "NOPASSWD" })
+  #   file.save
+  class Sudoers < BaseModel
+    # @return [AgueasParser] the Augeas parser for sudoers file
+    PARSER = AugeasParser.new("sudoers.lns")
+    private_constant :PARSER
+
+    # @return [String] default path to the sudoers file
+    DEFAULT_PATH = "/etc/sudoers".freeze
+    private_constant :DEFAULT_PATH
+
+    # @return [Matcher] matcher for the users collection
+    USERS_MATCHER = Matcher.new(collection: "spec")
+    private_constant :USERS_MATCHER
+
+    class << self
+      # Instantiates and loads a file
+      #
+      # This method is basically a shortcut to instantiate and load the content in just one call.
+      #
+      # @param file_handler [#read,#write] something able to read/write a string (like File)
+      # @return [Sudoers] File with the already loaded content
+      def load(file_path: DEFAULT_PATH, file_handler: Yast::TargetFile)
+        new(file_path: file_path, file_handler: file_handler).tap(&:load)
+      end
+    end
+
+    # Constructor
+    #
+    # @param file_handler [#read,#write] something able to read/write a string (like File)
+    #
+    # @see CFA::BaseModel#initialize
+    def initialize(file_path: DEFAULT_PATH, file_handler: nil)
+      super(PARSER, file_path, file_handler: file_handler)
+    end
+
+    # Read and prepare the data
+    #
+    # @see CFA::BaseModel#initialize
+    # @see #fix_collection_names
+    # @see #set_start_placer
+    def load
+      super
+
+      fix_collection_names(data)
+      @start_placer = set_start_placer
+    end
+
+    # Return all users specifications
+    #
+    # @return [Array<Hash>]
+    def users_specs
+      current_users.reduce([]) do |specs, user|
+        spec = {}
+        values = user[:value]
+
+        spec["user"] = values["user"]
+        spec["host"] = values["host_group"]["host"]
+        spec["commands"] = values["host_group"].collection("command").map do |command|
+          command.is_a?(AugeasTreeValue) ? command.value : command
+        end
+        spec["run_as"] = values["host_group"]["command[]"]["runas_user"]
+        spec["tag"] = values["host_group"]["command[]"]["tag"]
+
+        specs << spec.reject { |_, v| v.nil? }
+      end
+    end
+
+    # Remove all users specifications
+    def clean_users
+      data.delete(USERS_MATCHER)
+    end
+
+    # Add a new basic user specification
+    #
+    #
+    # A user specification determines which commands a user may run (and as what user) on specified
+    # hosts (who may run what, for short).
+    #
+    # Its basic structure is “who where = (as_whom) what”.
+    #
+    # E.g., with
+    #
+    #   root            ALL = (ALL) ALL
+    #   %wheel          ALL = (ALL) ALL
+    #
+    #   We let root and any user in group wheel run any command on any host as any user.
+    #
+    # See the sudoers manpage for more details.
+    #
+    # @param user_spec [Hash] a user specification
+    # @option user_spec [String] "user" who can run the command
+    # @option user_spec [String] "host" where the user can run the command
+    # @option user_spec [Array<String>] "commands" commands that the user can run
+    # @option user_spec [String] "run_as" as whom the commands will be run
+    # @option user_spec [String] "tag" the tag associated to the command (e.g. NOPASSWD)
+    def add_user(user_spec)
+      user = AugeasTree.new
+      host_group = AugeasTree.new
+
+      host_group.add("host", user_spec["host"])
+
+      commands = user_spec["commands"].reduce([]) do |commands, command|
+        augeas_command = AugeasTree.new
+        host_group.add("command[]", AugeasTreeValue.new(augeas_command, command))
+        commands << augeas_command
+      end
+
+      # For the time being, "runas_user" and "tag" options are added only to the first command,
+      # which means that they apply to all commands.
+      run_as = user_spec["run_as"].to_s.strip
+      tag = user_spec["tag"].to_s.strip
+      commands[0].add("runas_user", run_as) unless run_as.empty?
+      commands[0].add("tag", tag) unless tag.empty?
+
+      user.add("user", user_spec["user"])
+      user.add("host_group", host_group)
+
+      data.add("spec[]", user, placer)
+    end
+
+    private
+
+    attr_accessor :start_placer
+
+    # Return the current users collection
+    #
+    # @return [Array<Hash>]
+    def current_users
+      data.select(USERS_MATCHER)
+    end
+
+    COLLECTION_KEYS = ["spec", "command"].freeze
+    private_constant :COLLECTION_KEYS
+
+    # Fix collection names adding the missing "[]"
+    #
+    # When a collection has only one element, Augeas does not add "[]" suffix, reason why is
+    # necessary to fix at least those collextions that are going to be hitted for either, read or
+    # write.
+    #
+    # @param tree [AugeasTree,AugeasTreeValue]
+    def fix_collection_names(tree)
+      tree.data.each do |entry|
+        key, value = entry.values_at(:key, :value)
+
+        entry[:key] << "[]" if COLLECTION_KEYS.include?(key)
+        fix_collection_names(value) if value.is_a?(AugeasTree)
+        fix_collection_names(value.tree) if value.is_a?(AugeasTreeValue)
+      end
+    end
+
+    # Return the "next" placer where the user specification should be write
+    #
+    # When there are not users specifications yet, the start placer will be use. Otherwise, a new
+    # specification will be placed after the last one.
+    #
+    # @see #add_user
+    # @see #set_start_placer
+    #
+    # @return [CFA::Placer]
+    def placer
+      return start_placer if current_users.empty?
+
+      last_user = current_users.last
+
+      AfterPlacer.new(Matcher.new(key: last_user[:key], value_matcher: last_user[:value]))
+    end
+
+    # Set the the placer for the first user specification
+    #
+    # Depending on the defined users specifications, one of following criterias will be applied
+    #
+    #   * Generates the placer **after** the first one, or
+    #   * Look for the "#includedir .*sudoers.d.*" directive and generates the placer **before** it
+    #     if there are not users specifications yet.
+    #
+    # @see #placer
+    #
+    # @return [CFA::Placer]
+    def set_start_placer
+      first_user = current_users.first
+
+      if first_user
+        matcher = Matcher.new(key: first_user[:key], value_matcher: first_user[:value])
+
+        AfterPlacer.new(matcher)
+      else
+        matcher = Matcher.new(key: "#includedir", value_matcher: /sudoers\.d/)
+
+        BeforePlacer.new(matcher)
+      end
+    end
+  end
+end

--- a/test/cfa/sudoers_test.rb
+++ b/test/cfa/sudoers_test.rb
@@ -1,0 +1,183 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+require "cfa/sudoers"
+require "tmpdir"
+
+describe CFA::Sudoers do
+  subject(:sudoers) { described_class.new(file_path: file_path) }
+
+  let(:file_path) { example_file }
+  let(:example_file) { File.join(DATA_PATH, "sudoers_example") }
+
+  let(:yast_user_spec) do
+    {
+      "user"     => "yast",
+      "host"     => "ALL",
+      "run_as"   => "root",
+      "commands" => ["/sbin/yast2"],
+      "tag"      => "NOPASSWD"
+    }
+  end
+
+  let(:cli_user_spec) do
+    {
+      "user"     => "cli",
+      "host"     => "ALL",
+      "run_as"   => "ALL",
+      "commands" => ["/sbin/yast"]
+    }
+  end
+
+  describe ".load" do
+    it "loads the file content" do
+      expect(described_class).to receive(:new)
+        .with(hash_including(file_path: file_path))
+        .and_call_original
+
+      file = described_class.load(file_path: file_path)
+
+      expect(file.loaded?).to eq(true)
+    end
+  end
+
+  describe "#load" do
+    it "loads the file content" do
+      expect { sudoers.load }.to change { sudoers.loaded? }.from(false).to(true)
+    end
+  end
+
+  describe "#users_specs" do
+    before { sudoers.load }
+
+    context "when the loaded file already contains user spec" do
+      it "returns a collection holding all user specs" do
+        expect(sudoers.users_specs).to eq([
+          { "user" => "ALL", "host" => "ALL", "run_as" => "ALL", "commands" => ["ALL"], },
+          { "user" => "root", "host" => "ALL", "run_as" => "ALL", "commands" => ["ALL"], }
+        ])
+      end
+    end
+
+    context "when the loaded file does not contain user specs yet" do
+      let(:file_path) { File.join(DATA_PATH, "sudoers_no_specs_example") }
+
+      it "return an empty collection" do
+        expect(sudoers.users_specs).to eq([])
+      end
+
+      context "but a new user specs were added" do
+        before do
+          sudoers.add_user(yast_user_spec)
+          sudoers.add_user(cli_user_spec)
+        end
+
+        it "returns a collection holding all user specs" do
+          expect(sudoers.users_specs).to eq([yast_user_spec, cli_user_spec])
+        end
+      end
+    end
+  end
+
+  describe "#clean_users" do
+    before { sudoers.load }
+
+    it "removes all users specifications" do
+      initial_users_specs = sudoers.users_specs
+
+      sudoers.clean_users
+
+      expect(sudoers.users_specs).to_not eq(initial_users_specs)
+      expect(sudoers.users_specs).to eq([])
+    end
+  end
+
+  describe "#save" do
+    let(:file_path) { File.join(tmpdir, "sudoers") }
+    let(:tmpdir) { Dir.mktmpdir }
+
+    before do
+      # Use a copy of the example file
+      FileUtils.cp(example_file, file_path)
+
+      sudoers.load
+    end
+
+    after do
+      FileUtils.remove_entry(tmpdir)
+    end
+
+    context "when the file does not contain user specifications" do
+      let(:example_file) { File.join(DATA_PATH, "sudoers_no_specs_example") }
+
+      context "nor does it include the #includedir sudoers.d directive" do
+        let(:example_file) { File.join(DATA_PATH, "sudoers_old_example") }
+
+        it "writes new specifications at the end of file" do
+          sudoers.add_user(yast_user_spec)
+          sudoers.add_user(cli_user_spec)
+          sudoers.save
+
+          expect(File.read(file_path)).to match(/.*cli ALL = \(ALL\) \/sbin\/yast\Z/)
+        end
+      end
+
+      context "but does include the #includedir sudoers.d directive" do
+        it "writes new specifications before it" do
+          sudoers.add_user(yast_user_spec)
+          sudoers.add_user(cli_user_spec)
+          sudoers.save
+
+          expect(File.read(file_path)).to match(/.*yast.*cli.*\#includedir.*sudoers\.d.*/m)
+        end
+      end
+    end
+
+    context "when the file already contains user specs" do
+      it "writes new specifications after them" do
+        sudoers.add_user(yast_user_spec)
+        sudoers.add_user(cli_user_spec)
+        sudoers.save
+
+        expect(File.read(file_path)).to include(
+          "root ALL=(ALL) ALL\n" \
+          "yast ALL = (root) NOPASSWD : /sbin/yast2\n" \
+          "cli ALL = (ALL) /sbin/yast\n"
+        )
+      end
+
+      context "but they are cleaned before start adding new ones" do
+        it "writes new specs starting in the previous ones position" do
+          previous_first_position = File.read(file_path) =~ /.*^ALL.*ALL.*=\(ALL\)/
+
+          sudoers.clean_users
+          sudoers.add_user(yast_user_spec)
+          sudoers.add_user(cli_user_spec)
+          sudoers.save
+
+          new_first_position = File.read(file_path) =~ /.*^yast.*ALL.*=/
+
+          expect(new_first_position).to eq(previous_first_position)
+        end
+
+      end
+    end
+  end
+end

--- a/test/data/sudoers_example
+++ b/test/data/sudoers_example
@@ -65,8 +65,8 @@ Defaults !insults
 ## This allows use of an ordinary user account for administration of a freshly
 ## installed system. When configuring sudo, delete the two
 ## following lines:
-Defaults targetpw   # ask for the password of the target user i.e. root
-ALL   ALL=(ALL) ALL   # WARNING! Only use this together with 'Defaults targetpw'!
+# Defaults targetpw   # ask for the password of the target user i.e. root
+# ALL   ALL=(ALL) ALL   # WARNING! Only use this together with 'Defaults targetpw'!
 
 ##
 ## Runas alias specification

--- a/test/data/sudoers_example
+++ b/test/data/sudoers_example
@@ -1,0 +1,88 @@
+## sudoers file.
+##
+## This file MUST be edited with the 'visudo' command as root.
+## Failure to use 'visudo' may result in syntax or file permission errors
+## that prevent sudo from running.
+##
+## See the sudoers man page for the details on how to write a sudoers file.
+##
+
+##
+## Host alias specification
+##
+## Groups of machines. These may include host names (optionally with wildcards),
+## IP addresses, network numbers or netgroups.
+# Host_Alias	WEBSERVERS = www1, www2, www3
+
+##
+## User alias specification
+##
+## Groups of users.  These may consist of user names, uids, Unix groups,
+## or netgroups.
+# User_Alias	ADMINS = millert, dowdy, mikef
+
+##
+## Cmnd alias specification
+##
+## Groups of commands.  Often used to group related commands together.
+# Cmnd_Alias	PROCESSES = /usr/bin/nice, /bin/kill, /usr/bin/renice, \
+# 			    /usr/bin/pkill, /usr/bin/top
+# Cmnd_Alias	REBOOT = /sbin/halt, /sbin/reboot, /sbin/poweroff
+
+##
+## Defaults specification
+##
+## Prevent environment variables from influencing programs in an
+## unexpected or harmful way (CVE-2005-2959, CVE-2005-4158, CVE-2006-0151)
+Defaults always_set_home
+## Path that will be used for every command run from sudo
+Defaults secure_path="/usr/sbin:/usr/bin:/sbin:/bin"
+Defaults env_reset
+## Change env_reset to !env_reset in previous line to keep all environment variables
+## Following list will no longer be necessary after this change
+Defaults env_keep = "LANG LC_ADDRESS LC_CTYPE LC_COLLATE LC_IDENTIFICATION LC_MEASUREMENT LC_MESSAGES LC_MONETARY LC_NAME LC_NUMERIC LC_PAPER LC_TELEPHONE LC_ATIME LC_ALL LANGUAGE LINGUAS XDG_SESSION_COOKIE"
+## Comment out the preceding line and uncomment the following one if you need
+## to use special input methods. This may allow users to compromise the root
+## account if they are allowed to run commands without authentication.
+#Defaults env_keep = "LANG LC_ADDRESS LC_CTYPE LC_COLLATE LC_IDENTIFICATION LC_MEASUREMENT LC_MESSAGES LC_MONETARY LC_NAME LC_NUMERIC LC_PAPER LC_TELEPHONE LC_ATIME LC_ALL LANGUAGE LINGUAS XDG_SESSION_COOKIE"
+
+## Do not insult users when they enter an incorrect password.
+Defaults !insults
+
+## Uncomment to use a hard-coded PATH instead of the user's to find commands
+# Defaults secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+##
+## Uncomment to send mail if the user does not enter the correct password.
+# Defaults mail_badpass
+##
+## Uncomment to enable logging of a command's output, except for
+## sudoreplay and reboot.  Use sudoreplay to play back logged sessions.
+# Defaults log_output
+# Defaults!/usr/bin/sudoreplay !log_output
+# Defaults!REBOOT !log_output
+
+## In the default (unconfigured) configuration, sudo asks for the root password.
+## This allows use of an ordinary user account for administration of a freshly
+## installed system. When configuring sudo, delete the two
+## following lines:
+Defaults targetpw   # ask for the password of the target user i.e. root
+ALL   ALL=(ALL) ALL   # WARNING! Only use this together with 'Defaults targetpw'!
+
+##
+## Runas alias specification
+##
+
+##
+## User privilege specification
+##
+root ALL=(ALL) ALL
+
+## Uncomment to allow members of group wheel to execute any command
+# %wheel ALL=(ALL) ALL
+
+## Same thing without a password
+# %wheel ALL=(ALL) NOPASSWD: ALL
+
+## Read drop-in files from /etc/sudoers.d
+## (the '#' here does not indicate a comment)
+#includedir /etc/sudoers.d

--- a/test/data/sudoers_no_specs_example
+++ b/test/data/sudoers_no_specs_example
@@ -1,0 +1,87 @@
+## sudoers file.
+##
+## This file MUST be edited with the 'visudo' command as root.
+## Failure to use 'visudo' may result in syntax or file permission errors
+## that prevent sudo from running.
+##
+## See the sudoers man page for the details on how to write a sudoers file.
+##
+
+##
+## Host alias specification
+##
+## Groups of machines. These may include host names (optionally with wildcards),
+## IP addresses, network numbers or netgroups.
+# Host_Alias	WEBSERVERS = www1, www2, www3
+
+##
+## User alias specification
+##
+## Groups of users.  These may consist of user names, uids, Unix groups,
+## or netgroups.
+# User_Alias	ADMINS = millert, dowdy, mikef
+
+##
+## Cmnd alias specification
+##
+## Groups of commands.  Often used to group related commands together.
+# Cmnd_Alias	PROCESSES = /usr/bin/nice, /bin/kill, /usr/bin/renice, \
+# 			    /usr/bin/pkill, /usr/bin/top
+# Cmnd_Alias	REBOOT = /sbin/halt, /sbin/reboot, /sbin/poweroff
+
+##
+## Defaults specification
+##
+## Prevent environment variables from influencing programs in an
+## unexpected or harmful way (CVE-2005-2959, CVE-2005-4158, CVE-2006-0151)
+Defaults always_set_home
+## Path that will be used for every command run from sudo
+Defaults secure_path="/usr/sbin:/usr/bin:/sbin:/bin"
+Defaults env_reset
+## Change env_reset to !env_reset in previous line to keep all environment variables
+## Following list will no longer be necessary after this change
+Defaults env_keep = "LANG LC_ADDRESS LC_CTYPE LC_COLLATE LC_IDENTIFICATION LC_MEASUREMENT LC_MESSAGES LC_MONETARY LC_NAME LC_NUMERIC LC_PAPER LC_TELEPHONE LC_ATIME LC_ALL LANGUAGE LINGUAS XDG_SESSION_COOKIE"
+## Comment out the preceding line and uncomment the following one if you need
+## to use special input methods. This may allow users to compromise the root
+## account if they are allowed to run commands without authentication.
+#Defaults env_keep = "LANG LC_ADDRESS LC_CTYPE LC_COLLATE LC_IDENTIFICATION LC_MEASUREMENT LC_MESSAGES LC_MONETARY LC_NAME LC_NUMERIC LC_PAPER LC_TELEPHONE LC_ATIME LC_ALL LANGUAGE LINGUAS XDG_SESSION_COOKIE"
+
+## Do not insult users when they enter an incorrect password.
+Defaults !insults
+
+## Uncomment to use a hard-coded PATH instead of the user's to find commands
+# Defaults secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+##
+## Uncomment to send mail if the user does not enter the correct password.
+# Defaults mail_badpass
+##
+## Uncomment to enable logging of a command's output, except for
+## sudoreplay and reboot.  Use sudoreplay to play back logged sessions.
+# Defaults log_output
+# Defaults!/usr/bin/sudoreplay !log_output
+# Defaults!REBOOT !log_output
+
+## In the default (unconfigured) configuration, sudo asks for the root password.
+## This allows use of an ordinary user account for administration of a freshly
+## installed system. When configuring sudo, delete the two
+## following lines:
+# Defaults targetpw   # ask for the password of the target user i.e. root
+# ALL   ALL=(ALL) ALL   # WARNING! Only use this together with 'Defaults targetpw'!
+
+##
+## Runas alias specification
+##
+
+##
+## User privilege specification
+##
+
+## Uncomment to allow members of group wheel to execute any command
+# %wheel ALL=(ALL) ALL
+
+## Same thing without a password
+# %wheel ALL=(ALL) NOPASSWD: ALL
+
+## Read drop-in files from /etc/sudoers.d
+## (the '#' here does not indicate a comment)
+#includedir /etc/sudoers.d

--- a/test/data/sudoers_old_example
+++ b/test/data/sudoers_old_example
@@ -1,0 +1,16 @@
+# /etc/sudoers
+#
+# This file MUST be edited with the 'visudo' command as root.
+#
+# See the man page for details on how to write a sudoers file.
+#
+
+Defaults        env_reset
+
+# Host alias specification
+
+# User alias specification
+
+# Cmnd alias specification
+
+# User privilege specification

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -57,21 +57,3 @@ if ENV["COVERAGE"]
     ]
   end
 end
-
-# stub module to prevent its Import
-# Useful for modules from different yast packages, to avoid build dependencies
-def stub_module(name)
-  stubbed_class = Class.new do
-    # fake respond_to? to avoid failure of partial doubles
-    singleton_class.define_method(:respond_to?) do |_mname, _include_all = nil|
-      true
-    end
-
-    # needed to fake at least one class method to avoid Yast.import
-    singleton_class.define_method(:fake_method) do
-    end
-  end
-  Yast.const_set(name.to_sym, stubbed_class)
-end
-
-# stub classes from other modules to speed up a build

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,77 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+srcdir = File.expand_path("../src", __dir__)
+y2dirs = ENV.fetch("Y2DIR", "").split(":")
+ENV["Y2DIR"] = y2dirs.unshift(srcdir).join(":")
+
+# Ensure the tests runs with english locales
+ENV["LC_ALL"] = "en_US.UTF-8"
+ENV["LANG"] = "en_US.UTF-8"
+
+require "yast"
+require "yast/rspec"
+
+DATA_PATH = File.join(__dir__, "data")
+
+RSpec.configure do |c|
+  c.extend Yast::I18n # available in context/describe
+  c.include Yast::I18n
+  c.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+end
+
+# load it early, so other stuffs are not ignored
+if ENV["COVERAGE"]
+  require "simplecov"
+  SimpleCov.start do
+    add_filter "/test/"
+  end
+
+  # track all ruby files under src
+  SimpleCov.track_files("#{srcdir}/**/*.rb")
+
+  # use coveralls for on-line code coverage reporting at Travis CI
+  if ENV["TRAVIS"]
+    require "coveralls"
+    SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+      SimpleCov::Formatter::HTMLFormatter,
+      Coveralls::SimpleCov::Formatter
+    ]
+  end
+end
+
+# stub module to prevent its Import
+# Useful for modules from different yast packages, to avoid build dependencies
+def stub_module(name)
+  stubbed_class = Class.new do
+    # fake respond_to? to avoid failure of partial doubles
+    singleton_class.define_method(:respond_to?) do |_mname, _include_all = nil|
+      true
+    end
+
+    # needed to fake at least one class method to avoid Yast.import
+    singleton_class.define_method(:fake_method) do
+    end
+  end
+  Yast.const_set(name.to_sym, stubbed_class)
+end
+
+# stub classes from other modules to speed up a build


### PR DESCRIPTION
## Notes for reviewers

Some test could be failing because a problem writting multiple new elements to previously single element in CFA already fixed in version 1.0.2 via https://github.com/config-files-api/config_files_api/pull/33


## Problem

> `yast-sudo` kills all lines in /etc/sudoers after the users lines.

* https://bugzilla.suse.com/show_bug.cgi?id=1156929
* https://trello.com/c/rzO2lx0e

## Solution

In SLE-15, where [Config Files API](https://github.com/config-files-api/config_files_api) is available, to use a CFA model to write the user specification lines

## More details

:hourglass_flowing_sand: :construction: WIP