### PR TITLE
Do not truncate the sudoers file after writting changes

### DIFF
--- a/package/yast2-sudo.changes
+++ b/package/yast2-sudo.changes
@@ -2,6 +2,7 @@
 Wed Nov 13 15:56:18 UTC 2013 - jreidinger@suse.com
 
 - Add explicit COPYING file
+- 3.1.1
 
 -------------------------------------------------------------------
 Thu Sep 19 17:27:07 UTC 2013 - lslezak@suse.cz

--- a/package/yast2-sudo.changes
+++ b/package/yast2-sudo.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Dec 31 10:07:40 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Do not truncate the sudoers file after write changes
+  (bsc#1156929).
+- 3.1.2
+
+-------------------------------------------------------------------
 Wed Nov 13 15:56:18 UTC 2013 - jreidinger@suse.com
 
 - Add explicit COPYING file

--- a/package/yast2-sudo.spec
+++ b/package/yast2-sudo.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-sudo
-Version:        3.1.1
+Version:        3.1.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/servers_non_y2/ag_etc_sudoers
+++ b/src/servers_non_y2/ag_etc_sudoers
@@ -22,6 +22,13 @@ my $filename = "/etc/sudoers";
 #	);
 my @data2 = ();
 
+# bsc#1156929: by original design, the loop parsing the file is discarding all lines after the last
+# sudo rule found, which is no longer acceptable since there could be relevant content as directives
+# (with looks like a comment).
+#
+# So, lets keep the "rest of the file" to dump it at the end when re-writting the file.
+my $rest_of_file = "";
+
 sub parse_file {
 
     if ( !open( INFILE, $filename ) ) {
@@ -68,6 +75,9 @@ sub parse_file {
         $line    = "";
     }
 
+    # Keep the comments and directives found after last rule
+    $rest_of_file = $comment;
+
     close(INFILE);
     return 1;
 }
@@ -97,6 +107,9 @@ sub store_file {
 
         #delete($data{$key});
     }
+
+    # Dump comments and directives previously found after last rule
+    print OUTFILE $rest_of_file;
 
     close(OUTFILE);
 

--- a/src/servers_non_y2/ag_etc_sudoers
+++ b/src/servers_non_y2/ag_etc_sudoers
@@ -3,6 +3,15 @@
 # Author: Bubli <kmachalkova@suse.cz>
 #
 # An agent for parsing /etc/sudoers file
+#
+# TODO: add support to understand and manage #include and #includedir directives. As they start with
+# the pound sign ('#'), they look like a comment and are being processed as, which means
+#
+#   * the agent doesn't know/is ignoring the configuration defined by the files supposed to be
+#     included
+#   * those directives are being included as part of the "$previous_content", formerly "$comment",
+#     associated with the next rule or alias found while processing the file. This is wrong since
+#     they must not be moved or deleted along with the rule as if they were comments.
 
 use ycp;
 use strict;
@@ -24,7 +33,11 @@ my @data2 = ();
 
 # bsc#1156929: by original design, the loop parsing the file is discarding all lines after the last
 # sudo rule found, which is no longer acceptable since there could be relevant content as directives
-# (with looks like a comment).
+# like:
+#
+# #includedir /etc/sudoers.d
+#
+# which looks like a comment.
 #
 # So, lets keep the "rest of the file" to dump it at the end when re-writting the file.
 my $rest_of_file = "";
@@ -44,7 +57,7 @@ sub parse_file {
         chomp;
         $line .= $_;
 
-        # The line is empty, a comment, or a directive
+        # The line is empty, a comment, or a directive like "#includedir /etc/sudoers.d"
         if ( $line =~ m/^\s*$/ || $line =~ m/^#/ ) {
             $previous_content .= "$_\n";
             $line = "";

--- a/src/servers_non_y2/ag_etc_sudoers
+++ b/src/servers_non_y2/ag_etc_sudoers
@@ -11,148 +11,147 @@ use Data::Dumper;
 
 my $filename = "/etc/sudoers";
 
-my @data2 = ();  #= (
+# (
 #		"Host_Alias" => [ ["# Host Alias Specification","SERVERS", "ns, www, mail"],["","FOO", "www.foo.org"] ],
 #		"User_Alias" => [ ["# User Alias Specification", "BAT","foobar"], ["","WWW", "wwwrun"] ],
 #		"Cmnd_Alias" => [ ["# Command Alias Specification", "HALT", "/usr/sbin/halt, /usr/sbin/shutdown -h now,"], ["","REBOOT", "/sbin/reboot"] ],
 #		"Runas_Alias" => [ ],
-#		"Defaults" => [["#Defaults specification","env_reset",""],["","always_set_home",""] ],	
-#		'root' => [ ["# User privilege specification", "ALL", "(ALL) ALL"] ],	
-#		'%wheel' => [ ["# Same thing without password", "ALL",  "(ALL) NOPASSWD: HALT,REBOOT"] ],	
+#		"Defaults" => [["#Defaults specification","env_reset",""],["","always_set_home",""] ],
+#		'root' => [ ["# User privilege specification", "ALL", "(ALL) ALL"] ],
+#		'%wheel' => [ ["# Same thing without password", "ALL",  "(ALL) NOPASSWD: HALT,REBOOT"] ],
 #	);
-
-
+my @data2 = ();
 
 sub parse_file {
 
-	if (!open(INFILE, $filename)) {
-		return 1 if ($! == ENOENT); #File doesn't exist (yet)
-		y2error("Could not open file $filename for reading: %1", $!);
-		return 0;
-	}
+    if ( !open( INFILE, $filename ) ) {
+        return 1 if ( $! == ENOENT );    #File doesn't exist (yet)
+        y2error( "Could not open file $filename for reading: %1", $! );
+        return 0;
+    }
 
-	my $comment = "";
-        my $line = "";
-	while (<INFILE>) {
-		chomp;
-                $line .= $_;
-		#a line is a comment
-		if ($line =~ m/^\s*$/ || $line =~ m/^#/) {
-			$comment .= "$_\n";
-                        $line = "";
-			next; 
-		}
+    my $comment = "";
+    my $line    = "";
 
-		#a line is \-terminated multiline rule/alias
-		#save it and continue on the next line
-                if ($line =~ m/^(.*)\\$/){
-                  $line = $1;
-                  next;
-                }
+    while (<INFILE>) {
+        chomp;
+        $line .= $_;
 
-	        my $alias       = "";
+        # The line is a comment
+        if ( $line =~ m/^\s*$/ || $line =~ m/^#/ ) {
+            $comment .= "$_\n";
+            $line = "";
+            next;
+        }
 
-		my @entry2 = ();
-		if ($line =~ m/^(\S+)\s+(\S+)\s*=\s*([^#]*)/) {
-			$alias =$1;
-			push(@entry2, $comment, $alias, $2, $3);
-		}	
-		elsif ($line =~ m/^(\S+)\s+(\S+)/) {
-			$alias =$1;
-			push(@entry2, $comment, $alias, $2);
-		}
-	
-		push (@data2, \@entry2);
+        # The line is \-terminated multiline rule/alias
+        # Save it and continue on the next line
+        if ( $line =~ m/^(.*)\\$/ ) {
+            $line = $1;
+            next;
+        }
 
-		$comment = "";
-                $line = "";
-	}
+        my @entry2 = ();
+        my $alias  = "";
 
-	close (INFILE);
-	return 1;
+        if ( $line =~ m/^(\S+)\s+(\S+)\s*=\s*([^#]*)/ ) {
+            $alias = $1;
+            push( @entry2, $comment, $alias, $2, $3 );
+        } elsif ( $line =~ m/^(\S+)\s+(\S+)/ ) {
+            $alias = $1;
+            push( @entry2, $comment, $alias, $2 );
+        }
+
+        push( @data2, \@entry2 );
+
+        $comment = "";
+        $line    = "";
+    }
+
+    close(INFILE);
+    return 1;
 }
 
 sub store_line {
-	my $line = $_[0];
-	my ($comment, $type, $name, $members) = @{$line};
+    my $line = $_[0];
+    my ( $comment, $type, $name, $members ) = @{$line};
 
-	if($comment){
-		print OUTFILE $comment;
-	}
-	if($members) {
-		print OUTFILE $type,"\t", $name, " = ", $members, "\n";
-	}
-	else {
-		print OUTFILE $type,"\t", $name,"\n";
-	}
+    if ($comment) {
+        print OUTFILE $comment;
+    }
+
+    if ($members) {
+        print OUTFILE $type, "\t", $name, " = ", $members, "\n";
+    } else {
+        print OUTFILE $type, "\t", $name, "\n";
+    }
 }
 
 sub store_file {
+    open( OUTFILE, ">$filename.YaST2.new" )
+      or return y2error( "Could not open file $filename.YaST2.new for writing: %1", $! ), 0;
 
-	open(OUTFILE,">$filename.YaST2.new") 
-		or return y2error("Could not open file $filename.YaST2.new for writing: %1", $!), 0;
-	
-	#Dump the rest
-	foreach my $line (@data2) {
-		store_line($line);
-		#delete($data{$key});
-	}
+    # Write the data content
+    foreach my $line (@data2) {
+        store_line($line);
 
-	close(OUTFILE);
+        #delete($data{$key});
+    }
 
-	#try syntax checking - non-zero return value of system() means failure
-        # supress any output of visudo command, otherwise YaST thinks agent is exiting
-	my $status = system ("visudo -cqf $filename.YaST2.new >/dev/null 2>&1"); 
-	if ($status != 0){
-		return y2error("Syntax error in $filename.YaST2.new"), 0; 
-	}
+    close(OUTFILE);
 
-	if (-f $filename) {
-		rename $filename, "$filename.YaST2.save" or return y2error("Error creating backup: $!"), 0;
-	}
-	rename "$filename.YaST2.new", $filename or return y2error("Error moving temp file: $!"), 0;
-	
-	#Save /etc/sudoers with 0440 access rights - FaTE #300934
-	chmod(0440,$filename);
-	return 1;
-} 
+    # Try syntax checking - non-zero return value of system() means failure
+    # supress any output of visudo command, otherwise YaST thinks agent is exiting
+    my $status = system("visudo -cqf $filename.YaST2.new >/dev/null 2>&1");
 
-#parse whole file at once, fill in %data structure
-parse_file();
+    if ( $status != 0 ) {
+        return y2error("Syntax error in $filename.YaST2.new"), 0;
+    }
 
-#main loop
-while ( <STDIN> ) {
-	my ($command, $path, $argument) = ycp::ParseCommand ($_);
+    if ( -f $filename ) {
+        rename $filename, "$filename.YaST2.save"
+          or return y2error("Error creating backup: $!"), 0;
+    }
 
-	if($command eq "Read") {
-		ycp::Return(\@data2);
-	}
+    rename "$filename.YaST2.new", $filename
+      or return y2error("Error moving temp file: $!"), 0;
 
-	elsif($command eq "Write") {
-		my $result = "true";
-		if ($path eq "." && ref($argument) eq "ARRAY") {
-			@data2 = @{$argument};
-		}
-		elsif ($path eq "." && !defined($argument)) {
-			$result = store_file() ? "true" : "false";
-		}
-		else {
-			y2error("Invalid path $path, or argument:", ref($argument));
-			$result = "false";
-		}
-
-		ycp::Return($result);
-	}
-
-	elsif ($command eq "result") {
-		exit;
-	}
-
-	else {
-		y2error("Unknown instruction $command, or argument:", ref ($argument));
-		ycp::Return("false");
-	}
+    # Save /etc/sudoers with 0440 access rights - FaTE #300934
+    chmod( 0440, $filename );
+    return 1;
 }
 
-#Debug only !
-#print STDERR Dumper(\@data2);
+# Parse the whole file at once, fill in %data structure
+parse_file();
+
+# Main loop
+while (<STDIN>) {
+    my ( $command, $path, $argument ) = ycp::ParseCommand($_);
+
+    if ( $command eq "Read" ) {
+        ycp::Return( \@data2 );
+
+    } elsif ( $command eq "Write" ) {
+        my $result = "true";
+        if ( $path eq "." && ref($argument) eq "ARRAY" ) {
+            @data2 = @{$argument};
+        } elsif ( $path eq "." && !defined($argument) ) {
+            $result = store_file() ? "true" : "false";
+        } else {
+            y2error( "Invalid path $path, or argument:", ref($argument) );
+            $result = "false";
+        }
+
+        ycp::Return($result);
+
+    } elsif ( $command eq "result" ) {
+        exit;
+
+    } else {
+        y2error( "Unknown instruction $command, or argument:", ref($argument) );
+        ycp::Return("false");
+    }
+}
+
+# Debug only !
+# print STDERR Dumper(\@data2);

--- a/src/servers_non_y2/ag_etc_sudoers
+++ b/src/servers_non_y2/ag_etc_sudoers
@@ -37,16 +37,16 @@ sub parse_file {
         return 0;
     }
 
-    my $comment = "";
-    my $line    = "";
+    my $line             = "";
+    my $previous_content = "";
 
     while (<INFILE>) {
         chomp;
         $line .= $_;
 
-        # The line is a comment
+        # The line is empty, a comment, or a directive
         if ( $line =~ m/^\s*$/ || $line =~ m/^#/ ) {
-            $comment .= "$_\n";
+            $previous_content .= "$_\n";
             $line = "";
             next;
         }
@@ -63,20 +63,20 @@ sub parse_file {
 
         if ( $line =~ m/^(\S+)\s+(\S+)\s*=\s*([^#]*)/ ) {
             $alias = $1;
-            push( @entry2, $comment, $alias, $2, $3 );
+            push( @entry2, $previous_content, $alias, $2, $3 );
         } elsif ( $line =~ m/^(\S+)\s+(\S+)/ ) {
             $alias = $1;
-            push( @entry2, $comment, $alias, $2 );
+            push( @entry2, $previous_content, $alias, $2 );
         }
 
         push( @data2, \@entry2 );
 
-        $comment = "";
-        $line    = "";
+        $line             = "";
+        $previous_content = "";
     }
 
-    # Keep the comments and directives found after last rule
-    $rest_of_file = $comment;
+    # Keep the content after last rule found
+    $rest_of_file = $previous_content;
 
     close(INFILE);
     return 1;
@@ -84,10 +84,10 @@ sub parse_file {
 
 sub store_line {
     my $line = $_[0];
-    my ( $comment, $type, $name, $members ) = @{$line};
+    my ( $previous_content, $type, $name, $members ) = @{$line};
 
-    if ($comment) {
-        print OUTFILE $comment;
+    if ($previous_content) {
+        print OUTFILE $previous_content;
     }
 
     if ($members) {


### PR DESCRIPTION
## Problem

> yast-sudo kills all lines in /etc/sudoers after the users lines.
>
> In the /etc/sudoers file that we ship, we don't have any entry after the user lines, so as long as you only always use the yast-sudo module, you will be fine. But when you start editing it manually and you add anything that is not a user line after the user lines, those new entries are silently discarded the next time yast-sudo writes the file. — [Someone in the Trello card](https://trello.com/c/rzO2lx0e/1470-5-security-important-ostumbleweed-p1-1156929-yast2-sudo-destroys-etc-sudoers-deletes-all-lines-after-the-user-permission-specifi)

* https://bugzilla.suse.com/show_bug.cgi?id=1156929

## Why?

Because the [SCR agent](https://github.com/yast/yast-sudo/blob/4bbcc3f5d1cc4d04097b980af3dbd1b4f813a725/src/servers_non_y2/ag_etc_sudoers) discards all content lines after the last sudo rule found when parsing the file. Previous ones [were stored as a _comment_](https://github.com/yast/yast-sudo/blob/4bbcc3f5d1cc4d04097b980af3dbd1b4f813a725/src/servers_non_y2/ag_etc_sudoers) (aka _previous content_) of the rule.

## Solution

To keep the last "comment" (now, previous_content) as a _rest of file_ after the _parsing loop_

## Note for reviewers

I also took the opportunity to reformat the file using [Perltidy](http://perltidy.sourceforge.net/) since it had mixed styles. So, better to review it commit by commit.

## Tests

Although we tried to add unit tests for the agent (taking [test for the fstab agent as an example](https://github.com/yast/yast-yast2/blob/66bc64d08c6ff017b88e3cff63fd02d78bbcf7f1/library/general/test/agents_test/fstab_agent_test.rb)), it couldn't be possible :/ because this agent _does not respect changed root_ and _it will need additional code changes in yast2-core_ ([see how we use target_path to read AnyAgent](https://github.com/yast/yast-core/blob/master/agent-any/src/AnyAgent.cc#L699))

So, it was tested manually using a small file as example (see the screenshots below) an _User alias_ and a _sudo rule_ were added to test how the result before and after proposed changes.

## Screenshots

<details>
<summary>Click to show/hide some screenshots of the result of manual testing</summary>

---

<p align="center"><em>The original content of the file used as example</em></p>

![sudoers_example](https://user-images.githubusercontent.com/1691872/71618442-76c73e00-2bb7-11ea-8280-8c37f6b205b4.png)


---

<p align="center"><em>How the file looks after write an User alias and a sudo rule BEFORE apply the changes</em></p>

![sudoers_example_after](https://user-images.githubusercontent.com/1691872/71618464-91011c00-2bb7-11ea-8472-8bade9f021f6.png)


---


<p align="center"><em>How the file looks after write an User alias and a sudo rule AFTER apply the changes</em></p>

![sudoers_example_after_2](https://user-images.githubusercontent.com/1691872/71618476-9eb6a180-2bb7-11ea-8650-9dba862491bd.png)

</details>

## :warning: Warning

The agent design seems to be broken by default and proposed **changes are only a work-around to fix the original issue**: killing lines after the last sudo rule.

The fact to "store" the _previous content_ as a comment of the rule implies a weird and undesired behavior. Just imagine a sudoers file like this:

<details>
<summary>Click to show/hide</summary>

---

![weird_sudoers_file](https://user-images.githubusercontent.com/1691872/71647421-be041a80-2cee-11ea-876e-ea37914e9e63.png)

</details>

What if the user simply moves the rule for `tux` up?


<details>
<summary>Click to show/hide</summary>

---

| yast-sudo | /etc/sudoers |
|-----------|--------------|
| ![yast_sudo_mov](https://user-images.githubusercontent.com/1691872/71647474-5dc1a880-2cef-11ea-8957-3d6d0cda0de7.png) | ![etc_sudoers_after_move_tmux_rule_up](https://user-images.githubusercontent.com/1691872/71647462-323ebe00-2cef-11ea-9961-0ca68ead4da3.png) |

</details>

"It's" comment (remember: just a previous content) also moved up, which _could be_ nice for a less specific comment.

But let's move the `kilroy`'s rule to the top


<details>
<summary>Click to show/hide</summary>

---

| yast-sudo | /etc/sudoers |
|-----------|--------------|
| ![yast_sudo_moves_kilroy_to_the_top](https://user-images.githubusercontent.com/1691872/71647490-c14bd600-2cef-11ea-9592-e0e04c4cc6ce.png) | ![etc_sudoers_after_move_kilroy_top](https://user-images.githubusercontent.com/1691872/71647495-d1fc4c00-2cef-11ea-9608-c2ed7cf216ce.png) |

</details>

Now the _previous content_ wasn't a single comment. Instead, it was a mix of comments and a `#includedir /etc/sudoers` directive...and it's now misplaced at the top of the file, just after the user aliases.

And if that was not enough, things can be even worse: the user decides to remove the rule for `kilroy`...

<details>
<summary>Click to show/hide</summary>

---

| yast-sudo | /etc/sudoers |
|-----------|--------------|
| ![yast_sudo_removes_kilroy_rule](https://user-images.githubusercontent.com/1691872/71647527-4b943a00-2cf0-11ea-8436-4b87294e04cc.png) | ![etc_sudoers_after_remove_kilroy_rule](https://user-images.githubusercontent.com/1691872/71647531-5d75dd00-2cf0-11ea-9ca1-99b682cb85ff.png) |


</details>


... which means to remove all the associated previous content, including the `#includedir /etc/sudoers.d` directive.

As said, changes in this PR are only a work-around to fix the reported issue, but thanks to them we know now that the agent needs more fixes and improvements.
