### PR TITLE
[SLE-12-SP1] Fix version and changes file

### DIFF
--- a/package/yast2-sudo.changes
+++ b/package/yast2-sudo.changes
@@ -3,12 +3,13 @@ Tue Dec 31 10:07:40 UTC 2019 - David Diaz <dgonzalez@suse.com>
 
 - Do not truncate the sudoers file after write changes
   (bsc#1156929).
-- 3.1.2
+- 3.1.3
 
 -------------------------------------------------------------------
 Thu Dec  4 09:51:39 UTC 2014 - jreidinger@suse.com
 
 - remove X-KDE-Library from desktop file (bnc#899104)
+- 3.1.2
 
 -------------------------------------------------------------------
 Wed Nov 13 15:56:18 UTC 2013 - jreidinger@suse.com

--- a/package/yast2-sudo.spec
+++ b/package/yast2-sudo.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-sudo
-Version:        3.1.2
+Version:        3.1.3
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
Similar to #17, changes introduced in #14

> does not increase properly the version number, which is now 3.1.3 instead of 3.1.2
> 
> Also fix the changes file again, adding the 3.1.2 version forgotten in https://github.com/yast/yast-sudo/commit/a55e388f3a9a5d39b790c88a452f43dacb7f720b