### PR TITLE
Fixed user-visible messages (bsc#1084015)

### DIFF
--- a/package/yast2-sudo.changes
+++ b/package/yast2-sudo.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Feb 18 14:40:08 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Fixed user-visible messages (bsc#1084015)
+- 4.2.3
+
+-------------------------------------------------------------------
 Tue Dec 31 10:07:40 UTC 2019 - David Diaz <dgonzalez@suse.com>
 
 - Do not truncate the sudoers file after write changes

--- a/package/yast2-sudo.spec
+++ b/package/yast2-sudo.spec
@@ -18,7 +18,7 @@
 
 Name:           yast2-sudo
 Summary:        YaST2 - Sudo configuration
-Version:        4.2.2
+Version:        4.2.3
 Release:        0
 Url:            https://github.com/yast/yast-sudo
 Group:          System/YaST

--- a/src/include/sudo/helps.rb
+++ b/src/include/sudo/helps.rb
@@ -19,334 +19,312 @@
 # current contact information at www.novell.com.
 # ------------------------------------------------------------------------------
 
-# File:	include/sudo/helps.ycp
-# Package:	Configuration of sudo
-# Summary:	Help texts of all the dialogs
-# Authors:	Bubli <kmachalkova@suse.cz>
+# File: include/sudo/helps.ycp
+# Package:      Configuration of sudo
+# Summary:      Help texts for all the dialogs
+# Authors:      Bubli <kmachalkova@suse.cz>
 #
-# $Id: helps.ycp 27914 2006-02-13 14:32:08Z locilka $
 module Yast
   module SudoHelpsInclude
     def initialize_sudo_helps(include_target)
       textdomain "sudo"
 
-      # All helps are here
+      # All help texts are here
       @HELPS = {
         # Read dialog help 1/2
-        "read"            => _(
+        "read" => _(
           "<p><b><big>Initializing sudo Configuration</big></b><br>\n</p>\n"
         ) +
           # Read dialog help 2/2
           _(
-            "<p><b><big>Aborting Initialization:</big></b><br>\nSafely abort the configuration utility by pressing <b>Abort</b> now.</p>\n"
+            "<p><b><big>Aborting Initialization:</big></b><br>Safely abort the configuration utility by pressing <b>Abort</b> now.</p>"
           ),
         # Write dialog help 1/2
-        "write"           => _(
-          "<p><b><big>Saving sudo Configuration</big></b><br>\n</p>\n"
+        "write" => _(
+          "<p><b><big>Saving sudo Configuration</big></b><br></p>"
         ) +
           # Write dialog help 2/2
           _(
-            "<p><b><big>Aborting Saving:</big></b><br>\n" +
-              "Abort the save procedure by pressing <b>Abort</b>.\n" +
-              "An additional dialog informs whether it is safe to do so.\n" +
-              "</p>\n"
+            "<p><b><big>Aborting Saving:</big></b><br> " +
+              "Abort the save procedure by pressing <b>Abort</b>. " +
+              "An additional dialog informs whether it is safe to do so. " +
+              "</p>"
           ),
+
         # User Specification help 1/6
-        "spec"            => _(
-          "<p><b><big>Rules for sudo</big></b><br>\n" +
-            "\tRules for sudo basically determine which commands an user may run \n" +
-            "\ton specified hosts (optionally also as what user). Each rule\n" +
-            "\tis a tuple consisting of user, host and list of commands, with optional \n" +
-            "\tRunAs specification and additional tags. These are summarized \n" +
-            "\tin the following table. \n" +
-            "\t</p>\n" +
-            "\t"
+        "spec" => _(
+          "<p><b><big>Rules for sudo</big></b><br>" +
+            "Rules for sudo basically determine which commands a user may run " +
+            "on the specified hosts (optionally also as what user). Each rule " +
+            "is a tuple consisting of a user, a host and a list of commands, with an optional " +
+            "RunAs specification and additional tags. These are summarized " +
+            "in the following table. " +
+            "</p>"
         ) +
           # User Specification help 2/6
           _(
-            "<p><b>Users</b> column denotes local or system user or user alias. \n" +
-              "\t<b>Hosts</b> column determines, on which hosts, or group \n" +
-              "\tof hosts referred to by host alias an user may run specified commands.\n" +
-              "\t</p>\n" +
-              "\t"
+            "<p>The <b>Users</b> column specifies a local or system user or user alias. </p>" +
+              "<p>The <b>Hosts</b> column determines on which hosts or group " +
+              "of hosts referred to by a host alias a user may run the specified commands. " +
+              "</p>"
           ) +
           # User Specification help 3/6
           _(
-            "<b>RunAs</b> column is an\n" +
-              "\toptional parameter, containing user name (or alias) whose access privileges\n" +
-              "\twill be used to run commands. <b>NOPASSWD</b> is a tag, determining whether\n" +
-              "\tusers need to authorize themselves before running commands.\n" +
-              "\t</p>\n" +
-              "\t"
+            "<p>The <b>RunAs</b> column is an" +
+              "optional parameter containing the user name (or alias) whose access privileges " +
+              "will be used to run commands. <b>NOPASSWD</b> is a tag determining whether " +
+              "users need to authorize themselves before running commands. " +
+              "</p>"
           ) +
           # User Specification help 4/6
           _(
-            "<p>A set of commands that user can run on specified hosts is summarized \n" +
-              "\tin <b>Commands</b> column.  \n" +
-              "\t</p>\n" +
-              "\t"
+            "<p>A set of commands that user can run on specified hosts is summarized " +
+              "in the <b>Commands</b> column. " +
+              "</p>"
           ) +
           # User Specification help 5/6
           _(
-            "<p> To add a new rule, click on <b>Add</b> button and fill in appropriate \n" +
-              "\tentries. User name, hostname and command list must not be empty.\n" +
-              "\t</p>\n" +
-              "\t"
+            "<p>To add a new rule, click the <b>Add</b> button and fill in the appropriate " +
+              "fields. User name, hostname and command list must not be empty. " +
+              "</p>"
           ) +
           # User Specification help 5/6
           _(
-            "<p>To edit existing rule, select an entry from the table and click on \n" +
-              "\t<b>Edit</b> button. To delete selected entry, click on <b>Delete</b> button.\n" +
-              "\t</p> \n" +
-              "\t"
+            "<p>To edit an existing rule, select an item from the table and click the " +
+              "<b>Edit</b> button. To delete the selected item, click the <b>Delete</b> button. " +
+              "</p>"
           ),
+
         # Single User Specification help 1/4
-        "spec_single"     => _(
-          "<p><b>User Name or Alias</b> may be specified by single username (e.g.foo), group name prefixed\n" +
-            "\twith '%' (e.g. %bar), or user alias name. If \n" +
-            "\tkeyword 'ALL' is used, it stands for any user. Select from existing users, groups and aliases \n" +
-            "\tin drop-down menu, or enter your own value. \n" +
-            "\t</p>\n" +
-            "\t"
+        "spec_single" => _(
+          "<p><b>User Name or Alias</b> may be specified by a single username (e.g.foo), a group name prefixed " +
+            "with '%' (e.g. %bar), or a user alias name. " +
+            "The 'ALL' keyword can be used to specify any user. " +
+            "Select from the existing users, groups and aliases " +
+            "in the drop-down menu, or enter your own value. " +
+            "</p>"
         ) +
           _(
-            "<p><b>Hostname or Alias</b> entry consists of either hostname(e.g. www.example.com), single IP \n" +
-              "\taddress (e.g. 192.168.0.1), IP address combined with netmask, or host alias. If commands may be\n" +
-              "\trun on any host, use keyword 'ALL'. Hostname or IP address is matched against your own hostname\n" +
-              "\tor IP address, so if you don't intend to share one /etc/sudoers file between multiple machines, \n" +
-              "\t'ALL' or 'localhost' entry will be sufficient for almost all purposes. \n" +
-              "\t</p>\n" +
-              "\t"
+            "<p><b>Hostname or Alias</b> is either a hostname (e.g. www.example.com), a single IP " +
+              "address (e.g. 192.168.0.1), an IP address combined with a netmask, or a host alias. If commands may be " +
+              "run on any host, use the 'ALL' keyword. The hostname or IP address is matched against your own hostname " +
+              "or IP address, so if you don't intend to share one /etc/sudoers file between multiple machines, " +
+              "'ALL' or 'localhost' will be sufficient for almost all purposes. " +
+              "</p>"
           ) +
           # Single User Specification help 2/4
           _(
-            "<p><b>RunAs Username or Alias</b> is an optional parameter specifying an user, \n" +
-              "\twhose access privileges \n" +
-              "\twill be used to execute particular command. If empty, user <b>root</b> is the default\n" +
-              "\tone. It can be again single username, groupname prefixed with '%' or run_as alias name\n" +
-              "\tSelect from existing users, groups and aliases in drop-down menu, or enter your own value.\n" +
-              "\t</p>\n" +
-              "\t"
+            "<p><b>RunAs Username or Alias</b> is an optional parameter specifying a user " +
+              "whose access privileges " +
+              "will be used to execute a particular command. If empty, the <b>root</b> user is the default. " +
+              "It can be a single username, a groupname prefixed with '%' or a run_as alias name. " +
+              "Select from the existing users, groups and aliases in the drop-down menu, or enter your own value. " +
+              "</p>"
           ) +
           # Single User Specification help 3/4
           _(
-            "<p><b>No Password</b> is an optional tag. Normally, users have to authenticate\n" +
-              "\tthemselves (i.e. supply their own password, not root's one) before running particular \n" +
-              "\tcommand. Set No Password tag to 'Yes' if you want to\n" +
-              "\tdisable this authentication\n" +
-              "\t</p>\n" +
-              "\t"
+            "<p><b>No Password</b> is an optional tag. Normally, users have to authenticate " +
+              "themselves (i.e. supply their own password, not the root password) before running a particular " +
+              "command. Set the No Password tag to 'Yes' if you want to " +
+              "disable this authentication. " +
+              "</p>"
           ) +
           # Single User Specification help 4/4
           _(
-            "<p><b>Commands to Run</b> table is a list of commands (optionally with\n" +
-              "\tparameters), directories and command aliases that particular user will be allowed \n" +
-              "\tto run. If a directory name is used, any command in that directory can be run. \n" +
-              "\tAgain, keyword 'ALL' stands for any command, so use it with care.\n" +
-              "\t</p>\n" +
-              "\t"
+            "<p>The <b>Commands to Run</b> table is a list of commands (optionally with " +
+              "parameters), directories and command aliases that a particular user will be allowed " +
+              "to run. If a directory name is used, any command in that directory can be run. " +
+              "The 'ALL' keyword means 'any command', so use it with care. " +
+              "</p>"
           ) +
           _(
-            "To add a new command, click on <b>Add</b> button, fill in command name with optional\n" +
-              "\tparameters and click <b>OK</b>. To remove command, select appropriate entry from the table\n" +
-              "\tand click on <b>Delete</b> button.\n" +
-              "\t"
+            "<p>To add a new command, click the <b>Add</b> button, enter the command name with optional " +
+              "parameters and click <b>OK</b>. To remove a command, select the appropriate item from the table " +
+              "and click the <b>Delete</b> button. " +
+              "</p>"
           ),
-        #User Aliases help 1/3
-        "user_aliases"    => _(
-          "<p><b><big>User Aliases</big></b><br>\n" +
-            "\tIn this dialog, you can configure user aliases. User alias is a set of users that is given\n" +
-            "\tan unique name. This name is later used to refer to all users in this set in sudo configuration. \n" +
-            "\t</p> \n" +
-            "\t"
+
+        # User Aliases help 1/3
+        "user_aliases" => _(
+          "<p><b><big>User Aliases</big></b><br> " +
+            "In this dialog, you can configure user aliases. A user alias is a set of users that is given " +
+            "a unique name. This name is later used to refer to all users in this set in the sudo configuration. " +
+            "</p>"
         ) +
-          #User Aliases help 2/3
+          # User Aliases help 2/3
           _(
-            "<p>To add a new user alias, click on <b>Add</b> button and fill in appropriate entries. \n" +
-              "\tAlias name and list of users in the alias must not be empty. \n" +
-              "\t</p>\n" +
-              "\t"
+            "<p>To add a new user alias, click the <b>Add</b> button and fill in the appropriate fields. " +
+              "The alias name and the list of users in the alias must not be empty. " +
+              "</p>"
           ) +
-          #User Aliases help 3/3
+          # User Aliases help 3/3
           _(
-            "<p>To edit existing user alias, select an entry from the table and click on <b>Edit</b>\n" +
-              "\tbutton. To delete selected entry, click on <b>Delete</b> button. \n" +
-              "\t</p>\n" +
-              "\t"
+            "<p>To edit an existing user alias, select an item from the table and click the <b>Edit</b> " +
+              "button. To delete the selected item, click the <b>Delete</b> button. " +
+              "</p>"
           ),
-        #Host Aliases help 1/3
-        "host_aliases"    => _(
-          "<p><b><big>Host Aliases</big></b><br>\n" +
-            "\tIn this dialog, you can configure host aliases. Host alias is a set of hosts that is given\n" +
-            "\tan unique name. This name is later used to refer to all hosts in this set in sudo configuration. \n" +
-            "\t</p>\n" +
-            "\t"
+
+        # Host Aliases help 1/3
+        "host_aliases" => _(
+          "<p><b><big>Host Aliases</big></b><br>" +
+            "In this dialog, you can configure host aliases. A host alias is a set of hosts that is given " +
+            "a unique name. This name is later used to refer to all hosts in this set in the sudo configuration. " +
+            "</p>"
         ) +
-          #Host Aliases help 2/3
+          # Host Aliases help 2/3
           _(
-            "<p>To add a new host alias, click on <b>Add</b> button and fill in appropriate entries. \n" +
-              "\tAlias name and list of hosts in the alias must not be empty. \n" +
-              "\t</p>\n" +
-              "\t"
+            "<p>To add a new host alias, click the <b>Add</b> button and fill in the appropriate fields. " +
+              "Alias name and list of hosts in the alias must not be empty. " +
+              "</p>"
           ) +
-          #Host Aliases help 3/3
+          # Host Aliases help 3/3
           _(
-            "<p>To edit existing host alias, select an entry from the table and click on <b>Edit</b>\n" +
-              "\tbutton. To delete selected entry, click on <b>Delete</b> button. \n" +
-              "\t</p>\n" +
-              "\t"
+            "<p>To edit an existing host alias, select an item from the table and click the <b>Edit</b> " +
+              "button. To delete the selected item, click the <b>Delete</b> button. " +
+              "</p>"
           ),
-        #RunAs Aliases help 1/3
-        "runas_aliases"   => _(
-          "<p><b><big>RunAs Aliases</big></b><br>\n" +
-            "\tIn this dialog, you can configure RunAs aliases. RunAs alias is a set of users that is given\n" +
-            "\tan unique name. This name is later used to refer to all users in this set in sudo configuration. \n" +
-            "\t</p> \n" +
-            "\t"
+
+        # RunAs Aliases help 1/3
+        "runas_aliases" => _(
+          "<p><b><big>RunAs Aliases</big></b><br> " +
+            "In this dialog, you can configure RunAs aliases. A RunAs alias is a set of users that is given " +
+            "a unique name. This name is later used to refer to all users in this set in the sudo configuration. " +
+            "</p>"
         ) +
-          #RunAs Aliases help 2/3
+          # RunAs Aliases help 2/3
           _(
-            "<p>To add a new RunAs alias, click on <b>Add</b> button and fill in appropriate entries. \n" +
-              "\tAlias name and list of users in the alias must not be empty. \n" +
-              "\t</p>\n" +
-              "\t"
+            "<p>To add a new RunAs alias, click the <b>Add</b> button and fill in the appropriate fields. " +
+              "Alias name and list of users in the alias must not be empty. " +
+              "</p>"
           ) +
-          #RunAs Aliases help 3/3
+          # RunAs Aliases help 3/3
           _(
-            "<p>To edit existing RunAs alias, select an entry from the table and click on <b>Edit</b>\n" +
-              "\tbutton. To delete selected entry, click on <b>Delete</b> button. \n" +
-              "\t</p>\n" +
-              "\t"
+            "<p>To edit an existing RunAs alias, select an item from the table and click the <b>Edit</b> " +
+              "button. To delete the selected item, click the <b>Delete</b> button. " +
+              "</p>"
           ),
-        #Command Aliases help 1/3
+
+        # Command Aliases help 1/3
         "command_aliases" => _(
-          "<p><b><big>Command Aliases</big></b><br>\n" +
-            "\tIn this dialog, you can configure command aliases. Command alias is a set of commands \n" +
-            "\t(optionally with parameters) that is given an unique name. This name is then used to refer\n" +
-            "\tto all commands in this set in sudo configuration. \n" +
-            "\t</p>\n" +
-            "\t"
+          "<p><b><big>Command Aliases</big></b><br> " +
+            "In this dialog, you can configure command aliases. A command alias is a set of commands " +
+            "(optionally with parameters) that is given a unique name. This name is then used to refer " +
+            "to all commands in this set in the sudo configuration. " +
+            "</p>"
         ) +
-          #Command Aliases help 2/3
+          # Command Aliases help 2/3
           _(
-            "<p>To add a new command alias, click on <b>Add</b> button and fill in appropriate entries. \n" +
-              "\tAlias name and list of commands in the alias must not be empty. \n" +
-              "\t</p>\n" +
-              "\t"
+            "<p>To add a new command alias, click the <b>Add</b> button and fill in the appropriate fields. " +
+              "Alias name and list of commands in the alias must not be empty. " +
+              "</p>"
           ) +
-          #Command Aliases help 3/3
+          # Command Aliases help 3/3
           _(
-            "<p>To edit existing command alias, select an entry from the table and click on <b>Edit</b>\n" +
-              "\tbutton. To delete selected entry, click on <b>Delete</b> button. \n" +
-              "\t</p>\n" +
-              "\t"
+            "<p>To edit an existing command alias, select an item from the table and click the <b>Edit</b> " +
+              "button. To delete the selected item, click the <b>Delete</b> button. " +
+              "</p>"
           ),
-        #Single User Alias Help 1/2
-        "user_alias"      => _(
-          "<p><b><big>User Alias</big></b><br>\n" +
-            "\tUser alias consists of one or more users, system groups (prefixed with '%') or other\n" +
-            "\tuser aliases. It is given single name (must contain uppercase letters, numbers and underscore\tonly), which is then used to refer to all users in this alias.\n" +
-            "\t</p>\n" +
-            "\t"
+
+        # Single User Alias Help 1/2
+        "user_alias" => _(
+          "<p><b><big>User Alias</big></b><br>" +
+            "A user alias consists of one or more users, system groups (prefixed with '%') or other" +
+            "user aliases. It is given single name (must contain uppercase letters, numbers and " +
+            "underscore only), which is then used to refer to all users in this alias." +
+            "</p>"
         ) +
-          #Single User Alias Help 2/3
+          # Single User Alias Help 2/3
           _(
-            "<p>Enter unique name into <b>Alias Name</b> text entry. To add users or groups to the\n" +
-              "\talias, select user or group name from the drop-down menu and click on <b>Add</b> button.\n" +
-              "\tTo remove user from the alias, select appropriate entry from the table, and click on\n" +
-              "\t<b>Remove</b> button. To finish the configuration, click <b>OK</b>.\n" +
-              "\t</p>\n" +
-              "\t"
+            "<p>Enter a unique name into <b>Alias Name</b> input field. To add users or groups to the " +
+              "alias, select user or group name from the drop-down menu and click the <b>Add</b> button. " +
+              "To remove user from the alias, select the appropriate item from the table, and click the " +
+              "<b>Remove</b> button. To finish the configuration, click <b>OK</b>. " +
+              "</p>"
           ) +
-          #Single User Alias Help 3/3
+          # Single User Alias Help 3/3
           _(
-            "<b>Note:</b> Alias name must not be empty. Each alias must have at least one member.\n\t"
+            "<p><b>Note:</b> Alias name must not be empty. Each alias must have at least one member.</p>"
           ),
-        #Single Host Alias Help 1/4
-        "host_alias"      => _(
-          "<p><b><big>Host Alias</big></b><br>\n" +
-            "\tHost alias consists of one or more hostnames, single IP addresses, IP addresses\n" +
-            "\tcombined with netmask id dotted quad notation (e.g. 192.168.0.0/255.255.255.0) or\n" +
-            "\tCIDR number of bits notation (e.g. 192.168.0.0/24), or other host aliases. It is \n" +
-            "\tgiven single name (must contain uppercase letters, numbers and underscore only), which \n" +
-            "\tis then used to refer to all hosts in this alias.\n" +
-            "\t</p>\n" +
-            "\t"
+
+        # Single Host Alias Help 1/4
+        "host_alias" => _(
+          "<p><b><big>Host Alias</big></b><br> " +
+            "A host alias consists of one or more hostnames, single IP addresses, IP addresses " +
+            "combined with netmask id dotted quad notation (e.g. 192.168.0.0/255.255.255.0) or " +
+            "CIDR number of bits notation (e.g. 192.168.0.0/24), or other host aliases. It is " +
+            "given single name (must contain uppercase letters, numbers and underscore only), which " +
+            "is then used to refer to all hosts in this alias. " +
+            "</p>"
         ) +
-          #Single Host Alias Help 2/4
+          # Single Host Alias Help 2/4
           _(
-            "<p>Enter unique name into <b>Alias Name</b> text entry. To add hosts to the\n" +
-              "\talias, click on <b>Add</b> button. A pop-up window will appear, where you can enter\n" +
-              "\tvalid hostname or IP address and then click <b>OK</b>.\n" +
-              "\t<p>\n" +
-              "\t"
+            "<p>Enter a unique name into the <b>Alias Name</b> input field. To add hosts to the" +
+              "alias, click the <b>Add</b> button. A pop-up window will appear, where you can enter" +
+              "a valid hostname or IP address and then click <b>OK</b>." +
+              "<p>"
           ) +
-          #Single Host Alias Help 3/4
+          # Single Host Alias Help 3/4
           _(
-            "To remove host from the alias, select appropriate entry from the table, and click on\n" +
-              "\t<b>Remove</b> button. To finish the configuration, click <b>OK</b>.\n" +
-              "\t</p>\n" +
-              "\t"
+            "<p>To remove host from the alias, select the appropriate item from the table, and click the " +
+              "<b>Remove</b> button. To finish the configuration, click <b>OK</b>. " +
+              "</p>"
           ) +
-          #Single Host Alias Help 4/4
+          # Single Host Alias Help 4/4
           _(
-            "<b>Note:</b> Alias name must not be empty. Each alias must have at least one member.\n\t"
+            "<p><b>Note:</b> Alias name must not be empty. Each alias must have at least one member.</p>"
           ),
-        #Single RunAs Alias Help 1/2
-        "runas_alias"     => _(
-          "<p><b><big>RunAs Alias</big></b><br>\n" +
-            "\tRunAs alias is very similar to User Alias. It consists of one or more users, system groups \n" +
-            "\t(prefixed with '%') or other RunAs aliases. It is given single name (must contain \n" +
-            "\tuppercase letters, numbers and underscore only), which is then used to refer to all users \n" +
-            "\tin this alias.\n" +
-            "\t</p>\n" +
-            "\t"
+        # Single RunAs Alias Help 1/2
+        "runas_alias" => _(
+          "<p><b><big>RunAs Alias</big></b><br> " +
+            "A RunAs alias is very similar to a User alias. It consists of one or more users, system groups " +
+            "(prefixed with '%') or other RunAs aliases. It is given single name (must contain " +
+            "uppercase letters, numbers and underscore only), which is then used to refer to all users " +
+            "in this alias." +
+            "</p>"
         ) +
-          #Single User Alias Help 2/3
+          # Single User Alias Help 2/3
           _(
-            "<p>Enter unique name into <b>Alias Name</b> text entry. To add users or groups to the\n" +
-              "\talias, select user or group name from the drop-down menu and click on <b>Add</b> button.\n" +
-              "\tTo remove user from the alias, select appropriate entry from the table, and click on\n" +
-              "\t<b>Remove</b> button. To finish the configuration, click <b>OK</b>.\n" +
-              "\t</p>\n" +
-              "\t"
+            "<p>Enter a unique name into the <b>Alias Name</b> input field. To add users or groups to the " +
+              "alias, select user or group name from the drop-down menu and click the <b>Add</b> button. " +
+              "To remove user from the alias, select the appropriate item from the table, and click the " +
+              "<b>Remove</b> button. To finish the configuration, click <b>OK</b>. " +
+              "</p>"
           ) +
-          #Single User Alias Help 2/3
+          # Single User Alias Help 2/3
           _(
-            "<b>Note:</b> Alias name must not be empty. Each alias must have at least one member.\n\t"
+            "<p><b>Note:</b> The alias name must not be empty. Each alias must have at least one member.</p>"
           ),
-        #Single Command Alias Help 1/4
-        "command_alias"   => _(
-          "<p><b><big>Command Alias</big></b><br>\n" +
-            "\tCommand Alias is a list of one or more commands (with optional parameters), directories, or\n" +
-            "\tother command aliases. It is given single name (must contain uppercase letters, numbers and\n" +
-            "\tunderscore only), which is \n" +
-            "\tthen used to refer to all commands in this alias. A command can optionally have one or more\n" +
-            "\tparameters specified. If so, users can run the command with these parameters only. If a \n" +
-            "\tdirectory name is used, any command in that directory can be run.  \n" +
-            "\t</p>\n" +
-            "\t"
+
+        # Single Command Alias Help 1/4
+        "command_alias" => _(
+          "<p><b><big>Command Alias</big></b><br> " +
+            "A Command Alias is a list of one or more commands (with optional parameters), directories, or " +
+            "other command aliases. It is given single name (must contain uppercase letters, numbers and " +
+            "underscore only), which is " +
+            "then used to refer to all commands in this alias. A command can optionally have one or more " +
+            "parameters specified. If so, users can run the command with these parameters only. If a " +
+            "directory name is used, any command in that directory can be run. " +
+            "</p>"
         ) +
-          #Single Command Alias Help 2/4
+          # Single Command Alias Help 2/4
           _(
-            "<p>Enter unique name into <b>Alias Name</b> text entry. To add a new command to the alias,\n" +
-              "\tclick on <b>Add</b> button.A pop-up window will appear, where you can enter command name\n" +
-              "\t(or select one from file browser by clicking on <b>Browse</b> button. Additionally, you can\n" +
-              "\tspecify command parameters in <b>Parameters</b> text entry\n" +
-              "\t"
+            "<p>Enter a unique name into the <b>Alias Name</b> input field. To add a new command to the alias, " +
+              "click the <b>Add</b> button.A pop-up window will appear, where you can enter command name " +
+              "(or select one from file browser by clicking on <b>Browse</b> button. Additionally, you can " +
+              "specify command parameters in <b>Parameters</b> input field " +
+              "</p>"
           ) +
-          #Single Command Alias Help 3/4
+          # Single Command Alias Help 3/4
           _(
-            "To remove command from the alias, select appropriate entry from the table, and click on\n" +
-              "\t<b>Remove</b> button. To finish the configuration, click <b>OK</b>.\n" +
-              "\t</p>\n" +
-              "\t"
+            "To remove command from the alias, select the appropriate item from the table, and click the " +
+              "<b>Remove</b> button. To finish the configuration, click <b>OK</b>. " +
+              "</p>"
           ) +
-          #Single Command Alias Help 4/4
+          # Single Command Alias Help 4/4
           _(
-            "<b>Note:</b> Alias name must not be empty. Each alias must have at least one member.\n\t"
+            "<p><b>Note:</b> The alias name must not be empty. Each alias must have at least one member.</p>"
           )
-      } 
+      }
 
       # EOF
     end


### PR DESCRIPTION
## Bugzilla 

https://bugzilla.suse.com/show_bug.cgi?id=1084015


## Description

This puts en_US "translations" which are really fixes for broken English or broken translations back into the sources.

The help texts in this module were very broken English. I hope I caught most of that; there is probably still some weirdness left over.

I also fixed a lot of completely unneccessary weird control characters from the texts:
- Removed the leading `\t` tabs in most lines (WTF?!)
- Removed all `\n` newlines (completely useless since it's all RichText / HTML)
- Added a space character at the end of all continuation lines
- Added missing `<p>` and `</p>` tags

The overall paragraph / sentence structure is still somewhat weird in several places. But I didn't want to completely rewrite everything.

Also, the level of details is inconsistent; in most places, high-level concepts are explained, and then we tell the user that the "Edit" button edits an item and the "Delete" button deletes it. Duh; who would have thought?! IMHO we could simply omit that. Anybody even considering messing with the sudo configuration should clearly have mastered the basic concepts of how to work with a simple GUI.

## Test

`sudo rake install`, `sudo yast2 sudo`, clicked "Help" on the main dialog and after selecting each category in the main dialog.

I checked the formatting to make sure that I didn't miss any separating whitespace between lines that would make words stick together.