### PR TITLE
Document, test and improve unssuported scenarios

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+service_name: travis-ci

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ sudo.pot
 autom4te.cache
 *.m4
 *.ami
+/doc
+!/doc/autodocs
+/coverage
+/.yardoc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+sudo: required
+language: bash
+services:
+  - docker
+
+before_install:
+  - docker build -t yast-sudo-image .
+script:
+  # the "yast-travis-ruby" script is included in the base yastdevel/ruby image
+  # see https://github.com/yast/docker-yast-ruby/blob/master/yast-travis-ruby
+  - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-sudo-image yast-travis-ruby

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,2 @@
+FROM registry.opensuse.org/yast/head/containers/yast-ruby:latest
+COPY . /usr/src/app

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Intention of this module is to provide UI for configuring sudo.
 
-### Known Issues
+### Known Limitations
 
 - Module using for parsing sudoers own handcrafted perl parser which has
   limitations especially regarding new sudo changes as opposite to e.g.

--- a/README.md
+++ b/README.md
@@ -6,13 +6,19 @@ The intention of this module is to provide a User Interface for configuring
 ### Known Limitations
 
 - It uses a handcrafter Perl parser that has some limitations, especially when
-  it comes to deal with new `sudo` features. Alternatives like Augeas lenses are
-  more up-to-date.
+  it comes to deal with new `sudo` features or complex configuration.
+  Alternatives like Augeas lenses are more up-to-date. For specific limitations
+  see below
 - Support for `@include` and `@includedir` directive is limited. It just shows
   them in rules section, but nothing more. Also duplicated alias detection does
   not work across included files.
 - `sudo` configuration does not support multitags in rules, which leads to
   dropping it (caused by limitations of the parser, see above).
+  So `PASSWD:NOEXEC /bin/command` is changed to `PASSWD: /bin/command`
+- `sudo` configuration does not support command specific tags in rules, which leads to
+  dropping it (caused by limitations of the parser, see above).
+  So `PASSWD: /bin/command, NOPASSWD: /bin/command2` is changed to
+  `PASSWD: /bin/command,/bin/command2`
 - The module does not allow to see/edit the global configuration of `sudo` (key
   `Defaults`).
 - No support for commands digest feature.

--- a/README.md
+++ b/README.md
@@ -1,19 +1,20 @@
 ## YaST - Sudo Configuration
 
-Intention of this module is to provide UI for configuring sudo.
+The intention of this module is to provide a User Interface for configuring
+`sudo`.
 
 ### Known Limitations
 
-- Module using for parsing sudoers own handcrafted perl parser which has
-  limitations especially regarding new sudo changes as opposite to e.g.
-  augeas lenses that are more up-to data.
-- Support for `@include` and `@includedir` directive is limited. It just
-  shows them in rules section, but nothing more. Also duplicite alias detection
-  does not work across include files.
-- Sudo configuration does not support multitag in rule, which leads to dropping
-  it ( caused by limitation of parser, see above )
-- Module does not allow to see/edit global configuration of sudo ( key
-  `Defaults` )
-- No support for commands digest feature
-- Does not support `Cmd_Alias` alias for `Cmnd_Alias` and skips it
-- Can work only with /etc/sudoers
+- It uses a handcrafter Perl parser that has some limitations, especially when
+  it comes to deal with new `sudo` features. Alternatives like Augeas lenses are
+  more up-to-date.
+- Support for `@include` and `@includedir` directive is limited. It just shows
+  them in rules section, but nothing more. Also duplicated alias detection does
+  not work across included files.
+- `sudo` configuration does not support multitags in rules, which leads to
+  dropping it (caused by limitations of the parser, see above).
+- The module does not allow to see/edit the global configuration of `sudo` (key
+  `Defaults`).
+- No support for commands digest feature.
+- Does not support `Cmd_Alias` alias for `Cmnd_Alias` and skips it.
+- It can only work with `/etc/sudoers`.

--- a/README.md
+++ b/README.md
@@ -13,14 +13,10 @@ The intention of this module is to provide a User Interface for configuring
   them in rules section, but nothing more. Also duplicated alias detection does
   not work across included files.
 - `sudo` configuration does not support multitags in rules, which leads to
-  dropping it (caused by limitations of the parser, see above).
-  So `PASSWD:NOEXEC /bin/command` is changed to `PASSWD: /bin/command`
+  refuse to work with error message
 - `sudo` configuration does not support command specific tags in rules, which leads to
-  dropping it (caused by limitations of the parser, see above).
-  So `PASSWD: /bin/command, NOPASSWD: /bin/command2` is changed to
-  `PASSWD: /bin/command,/bin/command2`
+  refuse to work with error message
 - The module does not allow to see/edit the global configuration of `sudo` (key
   `Defaults`).
-- No support for commands digest feature.
-- Does not support `Cmd_Alias` alias for `Cmnd_Alias` and skips it.
+- No support for commands digest feature. If found then it refuse to work.
 - It can only work with `/etc/sudoers`.

--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@ The intention of this module is to provide a User Interface for configuring
 - It uses a handcrafter Perl parser that has some limitations, especially when
   it comes to deal with new `sudo` features or complex configuration.
   Alternatives like Augeas lenses are more up-to-date. For specific limitations
-  see below
+  see below.
 - Support for `@include` and `@includedir` directive is limited. It just shows
   them in rules section, but nothing more. Also duplicated alias detection does
   not work across included files.
 - `sudo` configuration does not support multitags in rules, which leads to
-  refuse to work with error message
+  refuse to work with error message.
 - `sudo` configuration does not support command specific tags in rules, which leads to
-  refuse to work with error message
+  refuse to work with error message.
 - The module does not allow to see/edit the global configuration of `sudo` (key
   `Defaults`).
-- No support for commands digest feature. If found then it refuse to work.
+- No support for commands digest feature. If found then it refuses to work.
 - It can only work with `/etc/sudoers`.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+## YaST - Sudo Configuration
+
+Intention of this module is to provide UI for configuring sudo.
+
+### Known Issues
+
+- Module using for parsing sudoers own handcrafted perl parser which has
+  limitations especially regarding new sudo changes as opposite to e.g.
+  augeas lenses that are more up-to data.
+- Support for `@include` and `@includedir` directive is limited. It just
+  shows them in rules section, but nothing more. Also duplicite alias detection
+  does not work across include files.
+- Sudo configuration does not support multitag in rule, which leads to dropping
+  it ( caused by limitation of parser, see above )
+- Module does not allow to see/edit global configuration of sudo ( key
+  `Defaults` )
+- No support for commands digest feature
+- Does not support `Cmd_Alias` alias for `Cmnd_Alias` and skips it
+- Can work only with /etc/sudoers

--- a/package/yast2-sudo.changes
+++ b/package/yast2-sudo.changes
@@ -3,7 +3,7 @@ Thu Oct  8 14:43:17 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - Support @include(-dir) directives
 - Support alternative name Cmd_Alias
-- report properly if some configuration yast2-sudo cannot read
+- report properly if yast2-sudo cannot read some configuration
 - improve error report if syntax failed after write
   (related to bsc#1156929)
 - 4.3.0

--- a/package/yast2-sudo.changes
+++ b/package/yast2-sudo.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Thu Oct  8 14:43:17 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
+
+- Support @include(-dir) directives
+- report properly if some configuration yast2-sudo cannot read
+- improve error report if syntax failed after write
+  (related to bsc#1156929)
+- 4.3.0
+
+-------------------------------------------------------------------
 Tue Feb 18 14:40:08 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Fixed user-visible messages (bsc#1084015)

--- a/package/yast2-sudo.changes
+++ b/package/yast2-sudo.changes
@@ -2,6 +2,7 @@
 Thu Oct  8 14:43:17 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - Support @include(-dir) directives
+- Support alternative name Cmd_Alias
 - report properly if some configuration yast2-sudo cannot read
 - improve error report if syntax failed after write
   (related to bsc#1156929)

--- a/package/yast2-sudo.spec
+++ b/package/yast2-sudo.spec
@@ -18,7 +18,7 @@
 
 Name:           yast2-sudo
 Summary:        YaST2 - Sudo configuration
-Version:        4.2.3
+Version:        4.3.0
 Release:        0
 Url:            https://github.com/yast/yast-sudo
 Group:          System/YaST

--- a/package/yast2-sudo.spec
+++ b/package/yast2-sudo.spec
@@ -33,7 +33,8 @@ Requires:       yast2-ruby-bindings >= 1.0.0
 
 BuildRequires:  yast2 yast2-users
 BuildRequires:  yast2-devtools >= 4.2.2
-BuildRequires:  rubygem(yast-rake)
+BuildRequires:  rubygem(%rb_default_ruby_abi:rspec)
+BuildRequires:  rubygem(%rb_default_ruby_abi:yast-rake)
 BuildRequires:  update-desktop-files
 
 BuildArch:      noarch

--- a/src/modules/Sudo.rb
+++ b/src/modules/Sudo.rb
@@ -160,6 +160,11 @@ module Yast
             if Builtins.regexpmatch(type, "^Defaults.*$")
               #do nothing, keep defaults untouched
               @defaults = Builtins.add(@defaults, line)
+            elsif type =~ /^sha\d+:/
+              raise UnsupportedSudoConfig.new(
+                _("Rules with digest are not supported."),
+                "#{type} #{Ops.get_string(line, 2, "")} #{Ops.get_string(line, 3, "")}"
+              )
             else
               m = {}
               cmd = []

--- a/src/modules/Sudo.rb
+++ b/src/modules/Sudo.rb
@@ -129,7 +129,7 @@ module Yast
                 "mem"  => lst
               }
             )
-          when "Cmnd_Alias"
+          when "Cmnd_Alias", "Cmd_Alias"
             lst = Builtins.maplist(
               Builtins.splitstring(Ops.get_string(line, 3, ""), ",")
             ) do |s|

--- a/src/modules/Sudo.rb
+++ b/src/modules/Sudo.rb
@@ -592,7 +592,7 @@ module Yast
       begin
         Report.Error(Message.CannotReadCurrentSettings) if !ReadSudoSettings2()
       rescue UnsupportedSudoConfig => e
-        msg = _("Unsupported configuration found. YaST2 exits now to prevent breaking system.")
+        msg = _("Unsupported configuration found. YaST will now exit to prevent from breaking the system.")
         msg += "\n" + _("Issue: ") + e.message
         msg += "\n" + _("Line content: ") + e.line
         Report.Error(msg)

--- a/src/servers_non_y2/ag_etc_sudoers
+++ b/src/servers_non_y2/ag_etc_sudoers
@@ -103,7 +103,8 @@ sub store_line {
         print OUTFILE $previous_content;
     }
 
-    if ($members) {
+    # do not break include directives
+    if ($members && $type !~ /^\@include/ ) {
         print OUTFILE $type, "\t", $name, " = ", $members, "\n";
     } else {
         print OUTFILE $type, "\t", $name, "\n";

--- a/test/data/associated_tag_example/sudoers
+++ b/test/data/associated_tag_example/sudoers
@@ -1,0 +1,1 @@
+myuser ALL = (root) NOPASSWD: /usr/bin/vim, PASSWD: /sbin/halt, /sbin/reboot

--- a/test/data/cmd_alias_config/sudoers
+++ b/test/data/cmd_alias_config/sudoers
@@ -1,0 +1,23 @@
+# Sample /etc/sudoers file.
+#
+# This file MUST be edited with the 'visudo' command as root.
+#
+# See the sudoers man page for the details on how to write a sudoers file.
+#
+
+##
+# Cmnd alias specification
+##
+Cmnd_Alias	DUMPS = /usr/sbin/dump, /usr/sbin/rdump, /usr/sbin/restore, \
+			/usr/sbin/rrestore, /usr/bin/mt
+Cmnd_Alias	KILL = /usr/bin/kill
+Cmnd_Alias	PRINTING = /usr/sbin/lpc, /usr/bin/lprm
+Cmnd_Alias	SHUTDOWN = /usr/sbin/shutdown
+Cmnd_Alias	HALT = /usr/sbin/halt
+Cmnd_Alias	REBOOT = /usr/sbin/reboot
+Cmnd_Alias	SHELLS = /sbin/sh, /usr/bin/sh, /usr/bin/csh, /usr/bin/ksh, \
+			 /usr/local/bin/tcsh, /usr/bin/rsh, \
+			 /usr/local/bin/zsh
+Cmn_Alias	SU = /usr/bin/su
+Cmn_Alias	VIPW = /usr/sbin/vipw, /usr/bin/passwd, /usr/bin/chsh, \
+		       /usr/bin/chfn

--- a/test/data/cmd_alias_config/sudoers
+++ b/test/data/cmd_alias_config/sudoers
@@ -18,6 +18,6 @@ Cmnd_Alias	REBOOT = /usr/sbin/reboot
 Cmnd_Alias	SHELLS = /sbin/sh, /usr/bin/sh, /usr/bin/csh, /usr/bin/ksh, \
 			 /usr/local/bin/tcsh, /usr/bin/rsh, \
 			 /usr/local/bin/zsh
-Cmn_Alias	SU = /usr/bin/su
-Cmn_Alias	VIPW = /usr/sbin/vipw, /usr/bin/passwd, /usr/bin/chsh, \
+Cmd_Alias	SU = /usr/bin/su
+Cmd_Alias	VIPW = /usr/sbin/vipw, /usr/bin/passwd, /usr/bin/chsh, \
 		       /usr/bin/chfn

--- a/test/data/default_config/sudoers
+++ b/test/data/default_config/sudoers
@@ -1,0 +1,87 @@
+## sudoers file.
+##
+## This file MUST be edited with the 'visudo' command as root.
+## Failure to use 'visudo' may result in syntax or file permission errors
+## that prevent sudo from running.
+##
+## See the sudoers man page for the details on how to write a sudoers file.
+##
+
+##
+## Host alias specification
+##
+## Groups of machines. These may include host names (optionally with wildcards),
+## IP addresses, network numbers or netgroups.
+# Host_Alias	WEBSERVERS = www1, www2, www3
+
+##
+## User alias specification
+##
+## Groups of users.  These may consist of user names, uids, Unix groups,
+## or netgroups.
+# User_Alias	ADMINS = millert, dowdy, mikef
+
+##
+## Cmnd alias specification
+##
+## Groups of commands.  Often used to group related commands together.
+# Cmnd_Alias	PROCESSES = /usr/bin/nice, /bin/kill, /usr/bin/renice, \
+# 			    /usr/bin/pkill, /usr/bin/top
+# Cmnd_Alias	REBOOT = /sbin/halt, /sbin/reboot, /sbin/poweroff
+
+##
+## Defaults specification
+##
+## Prevent environment variables from influencing programs in an
+## unexpected or harmful way (CVE-2005-2959, CVE-2005-4158, CVE-2006-0151)
+Defaults always_set_home
+## Path that will be used for every command run from sudo
+Defaults secure_path="/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:/usr/local/sbin"
+Defaults env_reset
+## Change env_reset to !env_reset in previous line to keep all environment variables
+## Following list will no longer be necessary after this change
+Defaults env_keep = "LANG LC_ADDRESS LC_CTYPE LC_COLLATE LC_IDENTIFICATION LC_MEASUREMENT LC_MESSAGES LC_MONETARY LC_NAME LC_NUMERIC LC_PAPER LC_TELEPHONE LC_ATIME LC_ALL LANGUAGE LINGUAS XDG_SESSION_COOKIE"
+## Comment out the preceding line and uncomment the following one if you need
+## to use special input methods. This may allow users to compromise the root
+## account if they are allowed to run commands without authentication.
+#Defaults env_keep = "LANG LC_ADDRESS LC_CTYPE LC_COLLATE LC_IDENTIFICATION LC_MEASUREMENT LC_MESSAGES LC_MONETARY LC_NAME LC_NUMERIC LC_PAPER LC_TELEPHONE LC_ATIME LC_ALL LANGUAGE LINGUAS XDG_SESSION_COOKIE"
+
+## Do not insult users when they enter an incorrect password.
+Defaults !insults
+
+## Uncomment to use a hard-coded PATH instead of the user's to find commands
+# Defaults secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+##
+## Uncomment to send mail if the user does not enter the correct password.
+# Defaults mail_badpass
+##
+## Uncomment to enable logging of a command's output, except for
+## sudoreplay and reboot.  Use sudoreplay to play back logged sessions.
+# Defaults log_output
+# Defaults!/usr/bin/sudoreplay !log_output
+# Defaults!REBOOT !log_output
+
+## In the default (unconfigured) configuration, sudo asks for the root password.
+## This allows use of an ordinary user account for administration of a freshly
+## installed system. When configuring sudo, delete the two
+## following lines:
+Defaults targetpw   # ask for the password of the target user i.e. root
+ALL   ALL=(ALL) ALL   # WARNING! Only use this together with 'Defaults targetpw'!
+
+##
+## Runas alias specification
+##
+
+##
+## User privilege specification
+##
+root ALL=(ALL) ALL
+
+## Uncomment to allow members of group wheel to execute any command
+# %wheel ALL=(ALL) ALL
+
+## Same thing without a password
+# %wheel ALL=(ALL) NOPASSWD: ALL
+
+## Read drop-in files from /etc/sudoers.d
+@includedir sudoers.d

--- a/test/data/digest_example/sudoers
+++ b/test/data/digest_example/sudoers
@@ -1,0 +1,1 @@
+sha256:865d0fc47d0aa1fe198e2d9b0cd5b27e35838dc8f73b6629adc646d3cc2d9c94 myuser ALL = (root) /sbin/reboot

--- a/test/data/multitag_single_line/sudoers
+++ b/test/data/multitag_single_line/sudoers
@@ -1,0 +1,1 @@
+myuser ALL = (root) NOPASSWD:NOEXEC: /usr/bin/vim, /sbin/halt, /sbin/reboot

--- a/test/data/nested_include_config/sudoers
+++ b/test/data/nested_include_config/sudoers
@@ -1,0 +1,75 @@
+## sudoers file.
+##
+## This file MUST be edited with the 'visudo' command as root.
+## Failure to use 'visudo' may result in syntax or file permission errors
+## that prevent sudo from running.
+##
+## See the sudoers man page for the details on how to write a sudoers file.
+##
+
+##
+## Host alias specification
+##
+## Groups of machines. These may include host names (optionally with wildcards),
+## IP addresses, network numbers or netgroups.
+# Host_Alias	WEBSERVERS = www1, www2, www3
+
+##
+## User alias specification
+##
+## Groups of users.  These may consist of user names, uids, Unix groups,
+## or netgroups.
+# User_Alias	ADMINS = millert, dowdy, mikef
+
+##
+## Cmnd alias specification
+##
+## Groups of commands.  Often used to group related commands together.
+# Cmnd_Alias	PROCESSES = /usr/bin/nice, /bin/kill, /usr/bin/renice, \
+# 			    /usr/bin/pkill, /usr/bin/top
+# Cmnd_Alias	REBOOT = /sbin/halt, /sbin/reboot, /sbin/poweroff
+
+##
+## Defaults specification
+##
+## Prevent environment variables from influencing programs in an
+## unexpected or harmful way (CVE-2005-2959, CVE-2005-4158, CVE-2006-0151)
+Defaults always_set_home
+## Path that will be used for every command run from sudo
+Defaults secure_path="/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:/usr/local/sbin"
+Defaults env_reset
+## Uncomment to use a hard-coded PATH instead of the user's to find commands
+# Defaults secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+##
+## Uncomment to send mail if the user does not enter the correct password.
+# Defaults mail_badpass
+##
+## Uncomment to enable logging of a command's output, except for
+## sudoreplay and reboot.  Use sudoreplay to play back logged sessions.
+# Defaults log_output
+# Defaults!/usr/bin/sudoreplay !log_output
+# Defaults!REBOOT !log_output
+
+## In the default (unconfigured) configuration, sudo asks for the root password.
+## This allows use of an ordinary user account for administration of a freshly
+## installed system. When configuring sudo, delete the two
+## following lines:
+Defaults targetpw   # ask for the password of the target user i.e. root
+ALL   ALL=(ALL) ALL   # WARNING! Only use this together with 'Defaults targetpw'!
+
+##
+## Runas alias specification
+##
+
+##
+## User privilege specification
+##
+root ALL=(ALL) ALL
+
+## Uncomment to allow members of group wheel to execute any command
+# %wheel ALL=(ALL) ALL
+
+## Same thing without a password
+# %wheel ALL=(ALL) NOPASSWD: ALL
+
+@include sudoers2

--- a/test/data/nested_include_config/sudoers2
+++ b/test/data/nested_include_config/sudoers2
@@ -1,0 +1,4 @@
+## Do not insult users when they enter an incorrect password.
+Defaults !insults
+
+@include sudoers3

--- a/test/data/nested_include_config/sudoers3
+++ b/test/data/nested_include_config/sudoers3
@@ -1,0 +1,6 @@
+## Change env_reset to !env_reset in previous line to keep all environment variables
+## Following list will no longer be necessary after this change
+Defaults env_keep = "LANG LC_ADDRESS LC_CTYPE LC_COLLATE LC_IDENTIFICATION LC_MEASUREMENT LC_MESSAGES LC_MONETARY LC_NAME LC_NUMERIC LC_PAPER LC_TELEPHONE LC_ATIME LC_ALL LANGUAGE LINGUAS XDG_SESSION_COOKIE"
+
+
+

--- a/test/data/old_includedir/sudoers
+++ b/test/data/old_includedir/sudoers
@@ -1,0 +1,87 @@
+## sudoers file.
+##
+## This file MUST be edited with the 'visudo' command as root.
+## Failure to use 'visudo' may result in syntax or file permission errors
+## that prevent sudo from running.
+##
+## See the sudoers man page for the details on how to write a sudoers file.
+##
+
+##
+## Host alias specification
+##
+## Groups of machines. These may include host names (optionally with wildcards),
+## IP addresses, network numbers or netgroups.
+# Host_Alias	WEBSERVERS = www1, www2, www3
+
+##
+## User alias specification
+##
+## Groups of users.  These may consist of user names, uids, Unix groups,
+## or netgroups.
+# User_Alias	ADMINS = millert, dowdy, mikef
+
+##
+## Cmnd alias specification
+##
+## Groups of commands.  Often used to group related commands together.
+# Cmnd_Alias	PROCESSES = /usr/bin/nice, /bin/kill, /usr/bin/renice, \
+# 			    /usr/bin/pkill, /usr/bin/top
+# Cmnd_Alias	REBOOT = /sbin/halt, /sbin/reboot, /sbin/poweroff
+
+##
+## Defaults specification
+##
+## Prevent environment variables from influencing programs in an
+## unexpected or harmful way (CVE-2005-2959, CVE-2005-4158, CVE-2006-0151)
+Defaults always_set_home
+## Path that will be used for every command run from sudo
+Defaults secure_path="/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:/usr/local/sbin"
+Defaults env_reset
+## Change env_reset to !env_reset in previous line to keep all environment variables
+## Following list will no longer be necessary after this change
+Defaults env_keep = "LANG LC_ADDRESS LC_CTYPE LC_COLLATE LC_IDENTIFICATION LC_MEASUREMENT LC_MESSAGES LC_MONETARY LC_NAME LC_NUMERIC LC_PAPER LC_TELEPHONE LC_ATIME LC_ALL LANGUAGE LINGUAS XDG_SESSION_COOKIE"
+## Comment out the preceding line and uncomment the following one if you need
+## to use special input methods. This may allow users to compromise the root
+## account if they are allowed to run commands without authentication.
+#Defaults env_keep = "LANG LC_ADDRESS LC_CTYPE LC_COLLATE LC_IDENTIFICATION LC_MEASUREMENT LC_MESSAGES LC_MONETARY LC_NAME LC_NUMERIC LC_PAPER LC_TELEPHONE LC_ATIME LC_ALL LANGUAGE LINGUAS XDG_SESSION_COOKIE"
+
+## Do not insult users when they enter an incorrect password.
+Defaults !insults
+
+## Uncomment to use a hard-coded PATH instead of the user's to find commands
+# Defaults secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+##
+## Uncomment to send mail if the user does not enter the correct password.
+# Defaults mail_badpass
+##
+## Uncomment to enable logging of a command's output, except for
+## sudoreplay and reboot.  Use sudoreplay to play back logged sessions.
+# Defaults log_output
+# Defaults!/usr/bin/sudoreplay !log_output
+# Defaults!REBOOT !log_output
+
+## In the default (unconfigured) configuration, sudo asks for the root password.
+## This allows use of an ordinary user account for administration of a freshly
+## installed system. When configuring sudo, delete the two
+## following lines:
+Defaults targetpw   # ask for the password of the target user i.e. root
+ALL   ALL=(ALL) ALL   # WARNING! Only use this together with 'Defaults targetpw'!
+
+##
+## Runas alias specification
+##
+
+##
+## User privilege specification
+##
+root ALL=(ALL) ALL
+
+## Uncomment to allow members of group wheel to execute any command
+# %wheel ALL=(ALL) ALL
+
+## Same thing without a password
+# %wheel ALL=(ALL) NOPASSWD: ALL
+
+## Read drop-in files from /etc/sudoers.d
+#includedir sudoers.d

--- a/test/data/richful_example/sudoers
+++ b/test/data/richful_example/sudoers
@@ -1,0 +1,129 @@
+# Sample /etc/sudoers file.
+#
+# This file MUST be edited with the 'visudo' command as root.
+#
+# See the sudoers man page for the details on how to write a sudoers file.
+#
+
+##
+# User alias specification
+##
+User_Alias	FULLTIMERS = millert, mikef, dowdy
+User_Alias	PARTTIMERS = bostley, jwfox, crawl
+User_Alias	WEBMASTERS = will, wendy, wim
+
+##
+# Runas alias specification
+##
+Runas_Alias	OP = root, operator
+Runas_Alias	DB = oracle, sybase
+
+##
+# Host alias specification
+##
+Host_Alias	SPARC = bigtime, eclipse, moet, anchor:\
+		SGI = grolsch, dandelion, black:\
+		ALPHA = widget, thalamus, foobar:\
+		HPPA = boa, nag, python
+Host_Alias	CUNETS = 128.138.0.0/255.255.0.0
+Host_Alias	CSNETS = 128.138.243.0, 128.138.204.0/24, 128.138.242.0
+Host_Alias	SERVERS = master, mail, www, ns
+Host_Alias	CDROM = orion, perseus, hercules
+
+##
+# Cmnd alias specification
+##
+Cmnd_Alias	DUMPS = /usr/sbin/dump, /usr/sbin/rdump, /usr/sbin/restore, \
+			/usr/sbin/rrestore, /usr/bin/mt
+Cmnd_Alias	KILL = /usr/bin/kill
+Cmnd_Alias	PRINTING = /usr/sbin/lpc, /usr/bin/lprm
+Cmnd_Alias	SHUTDOWN = /usr/sbin/shutdown
+Cmnd_Alias	HALT = /usr/sbin/halt
+Cmnd_Alias	REBOOT = /usr/sbin/reboot
+Cmnd_Alias	SHELLS = /sbin/sh, /usr/bin/sh, /usr/bin/csh, /usr/bin/ksh, \
+			 /usr/local/bin/tcsh, /usr/bin/rsh, \
+			 /usr/local/bin/zsh
+Cmnd_Alias	SU = /usr/bin/su
+Cmnd_Alias	VIPW = /usr/sbin/vipw, /usr/bin/passwd, /usr/bin/chsh, \
+		       /usr/bin/chfn
+
+##
+# Override built-in defaults
+##
+Defaults               syslog=auth
+Defaults>root          !set_logname
+Defaults:FULLTIMERS    !lecture
+Defaults:millert       !authenticate
+Defaults@SERVERS       log_year, logfile=/var/log/sudo.log
+
+##
+# User specification
+##
+
+# root and users in group wheel can run anything on any machine as any user
+root		ALL = (ALL) ALL
+%wheel		ALL = (ALL) ALL
+
+# full time sysadmins can run anything on any machine without a password
+FULLTIMERS	ALL = NOPASSWD: ALL
+
+# part time sysadmins may run anything but need a password
+PARTTIMERS	ALL = ALL
+
+# jack may run anything on machines in CSNETS
+jack		CSNETS = ALL
+
+# lisa may run any command on any host in CUNETS (a class B network)
+lisa		CUNETS = ALL
+
+# operator may run maintenance commands and anything in /usr/oper/bin/
+operator	ALL = DUMPS, KILL, SHUTDOWN, HALT, REBOOT, PRINTING,\
+		sudoedit /etc/printcap, /usr/oper/bin/
+
+# joe may su only to operator
+joe		ALL = /usr/bin/su operator
+
+# pete may change passwords for anyone but root on the hp snakes
+pete		HPPA = /usr/bin/passwd [A-z]*, !/usr/bin/passwd root
+
+# bob may run anything on the sparc and sgi machines as any user
+# listed in the Runas_Alias "OP" (ie: root and operator)
+bob		SPARC = (OP) ALL : SGI = (OP) ALL
+
+# jim may run anything on machines in the biglab netgroup
+jim		+biglab = ALL
+
+# users in the secretaries netgroup need to help manage the printers
+# as well as add and remove users
++secretaries	ALL = PRINTING, /usr/bin/adduser, /usr/bin/rmuser
+
+# fred can run commands as oracle or sybase without a password
+fred		ALL = (DB) NOPASSWD: ALL
+
+# on the alphas, john may su to anyone but root and flags are not allowed
+john		ALPHA = /usr/bin/su [!-]*, !/usr/bin/su *root*
+
+# jen can run anything on all machines except the ones
+# in the "SERVERS" Host_Alias
+jen		ALL, !SERVERS = ALL
+
+# jill can run any commands in the directory /usr/bin/, except for
+# those in the SU and SHELLS aliases.
+jill		SERVERS = /usr/bin/, !SU, !SHELLS
+
+# steve can run any command in the directory /usr/local/op_commands/
+# as user operator.
+steve		CSNETS = (operator) /usr/local/op_commands/
+
+# matt needs to be able to kill things on his workstation when
+# they get hung.
+matt		valkyrie = KILL
+
+# users in the WEBMASTERS User_Alias (will, wendy, and wim)
+# may run any command as user www (which owns the web pages)
+# or simply su to www.
+WEBMASTERS	www = (www) ALL, (root) /usr/bin/su www
+
+# anyone can mount/unmount a cd-rom on the machines in the CDROM alias
+ALL		CDROM = NOPASSWD: /sbin/umount /CDROM,\
+		/sbin/mount -o nosuid\,nodev /dev/cd0a /CDROM

--- a/test/sudo_test.rb
+++ b/test/sudo_test.rb
@@ -153,41 +153,22 @@ describe Yast::Sudo do
       expect(subject.GetRules).to eq expected_rules
     end
 
-    it "parses and set rules with multiple tags" do
-      pending "it use just first tag"
-
+    it "raises UnsupportedSudoConfig for rules with multiple tags" do
       lines = [
         { type: "user1", name: "ALL", rest: "NOPASSWD:NOEXEC: /usr/bin/su operator" },
       ]
       mock_sudo(lines)
 
-      expected_rules = [
-        { "user" => "user1", "host" => "ALL", "comment" => "",
-          "tag" => "NOPASSWD:NOEXEC:", "commands" => ["/usr/bin/su operator"] },
-      ]
-
-      subject.ReadSudoSettings2
-
-      expect(subject.GetRules).to eq expected_rules
+      expect{subject.ReadSudoSettings2}.to raise_error(Yast::UnsupportedSudoConfig)
     end
 
     it "parses and set rules with associated tags" do
-      pending "it removes whole first command and keep wrong tag with rest"
-
       lines = [
         { type: "user1", name: "ALL", rest: "NOPASSWD: /usr/bin/su operator, PASSWD: /bin/test" },
       ]
       mock_sudo(lines)
 
-      expected_rules = [
-        { "user" => "user1", "host" => "ALL", "comment" => "",
-          # FIXME: not sure how here should look expected result as data structure is bad
-          "tag" => "NOPASSWD:", "commands" => ["/usr/bin/su operator", "PASSWD: /bin/test"] },
-      ]
-
-      subject.ReadSudoSettings2
-
-      expect(subject.GetRules).to eq expected_rules
+      expect{subject.ReadSudoSettings2}.to raise_error(Yast::UnsupportedSudoConfig)
     end
 
     it "parses and set rules with run as specified" do

--- a/test/sudo_test.rb
+++ b/test/sudo_test.rb
@@ -162,7 +162,7 @@ describe Yast::Sudo do
       expect{subject.ReadSudoSettings2}.to raise_error(Yast::UnsupportedSudoConfig)
     end
 
-    it "parses and set rules with associated tags" do
+    it "raises UnsupportedSudoConfig for rules with associated tags" do
       lines = [
         { type: "user1", name: "ALL", rest: "NOPASSWD: /usr/bin/su operator, PASSWD: /bin/test" },
       ]
@@ -186,6 +186,16 @@ describe Yast::Sudo do
       subject.ReadSudoSettings2
 
       expect(subject.GetRules).to eq expected_rules
+    end
+
+    it "raises UnsupportedSudoConfig for rules with digest" do
+      lines = [
+        { type: "sha256:865d0fc47d0aa1fe198e2d9b0cd5b27e35838dc8f73b6629adc646d3cc2d9c94",
+          name: "user1" },
+      ]
+      mock_sudo(lines)
+
+      expect{subject.ReadSudoSettings2}.to raise_error(Yast::UnsupportedSudoConfig)
     end
   end
 end

--- a/test/sudo_test.rb
+++ b/test/sudo_test.rb
@@ -98,8 +98,6 @@ describe Yast::Sudo do
     end
 
     it "parses and set command aliases with Cmd_Alias alternative name" do
-      pending "Not recognized yet"
-
       lines = [
         { comment: "test\n", type: "Cmd_Alias", name: "ALIAS2", rest: "/bin/cmd1" }
       ]

--- a/test/sudo_test.rb
+++ b/test/sudo_test.rb
@@ -1,0 +1,193 @@
+require_relative "test_helper"
+
+Yast.import "Sudo"
+
+describe Yast::Sudo do
+  subject { described_class }
+
+  describe "#ReadSudoSettings2" do
+    before do
+      # reset internal variables as e.g. read just adds new entries
+      # and does not reset old
+      subject.main
+    end
+
+    # @param lines [Array<Hash>] list of hash with keys :comment for
+    #  comments before line, :type for first word on line, :name for the
+    #  second and :rest for rest of line without initial "="
+    def mock_sudo(lines)
+      scr_result = lines.map do |l|
+        [l[:comment] || "", l[:type], l[:name], l[:rest]]
+      end
+      allow(Yast::SCR).to receive(:Read).with(path(".sudo"))
+        .and_return(scr_result)
+    end
+
+    it "parses and set host aliases" do
+      lines = [
+        { type: "Host_Alias", name: "ALIAS1", rest: "test.suse.cz" },
+        { comment: "test\n", type: "Host_Alias", name: "ALIAS2",
+          rest: "test.suse.de, test2.suse.de,\ttest3.suse.de" }
+      ]
+      mock_sudo(lines)
+
+      expected_aliases = [
+        { "c" => "", "name" => "ALIAS1", "mem" => ["test.suse.cz"] },
+        { "c" => "test\n", "name" => "ALIAS2",
+          "mem" => ["test.suse.de", "test2.suse.de", "test3.suse.de"] }
+      ]
+
+      subject.ReadSudoSettings2
+
+      expect(subject.GetHostAliases2).to eq expected_aliases
+    end
+
+    it "parses and set user aliases" do
+      lines = [
+        { type: "User_Alias", name: "ALIAS1", rest: "user1" },
+        { comment: "test\n", type: "User_Alias", name: "ALIAS2",
+          rest: "user2, user3,\tuser4" }
+      ]
+      mock_sudo(lines)
+
+      expected_aliases = [
+        { "c" => "", "name" => "ALIAS1", "mem" => ["user1"] },
+        { "c" => "test\n", "name" => "ALIAS2",
+          "mem" => ["user2", "user3", "user4"] }
+      ]
+
+      subject.ReadSudoSettings2
+
+      expect(subject.GetUserAliases2).to eq expected_aliases
+    end
+
+    it "parses and set command aliases" do
+      lines = [
+        { type: "Cmnd_Alias", name: "ALIAS1", rest: "/bin/cmd" },
+        { comment: "test\n", type: "Cmnd_Alias", name: "ALIAS2",
+          rest: "/bin/cmd1, /bin/cmd2,\t/bin/cmd3" }
+      ]
+      mock_sudo(lines)
+
+      expected_aliases = [
+        { "c" => "", "name" => "ALIAS1", "mem" => ["/bin/cmd"] },
+        { "c" => "test\n", "name" => "ALIAS2",
+          "mem" => ["/bin/cmd1", "/bin/cmd2", "/bin/cmd3"] }
+      ]
+
+      subject.ReadSudoSettings2
+
+      expect(subject.GetCmndAliases2).to eq expected_aliases
+    end
+
+    it "parses and set command aliases with digest" do
+      lines = [
+        { comment: "test\n", type: "Cmnd_Alias", name: "ALIAS2",
+          rest: "/bin/cmd1, sha224:0GomF8mNN3wlDt1HD9XldjJ3SNgpFdbjO1+NsQ== /home/cmds/cmd2" }
+      ]
+      mock_sudo(lines)
+
+      expected_aliases = [
+        { "c" => "test\n", "name" => "ALIAS2",
+          "mem" => ["/bin/cmd1", "sha224:0GomF8mNN3wlDt1HD9XldjJ3SNgpFdbjO1+NsQ== /home/cmds/cmd2"] }
+      ]
+
+      subject.ReadSudoSettings2
+
+      expect(subject.GetCmndAliases2).to eq expected_aliases
+    end
+
+    it "parses and set command aliases with Cmd_Alias alternative name" do
+      pending "Not recognized yet"
+
+      lines = [
+        { comment: "test\n", type: "Cmd_Alias", name: "ALIAS2", rest: "/bin/cmd1" }
+      ]
+      mock_sudo(lines)
+
+      expected_aliases = [
+        { "c" => "test\n", "name" => "ALIAS2", "mem" => ["/bin/cmd1"] }
+      ]
+
+      subject.ReadSudoSettings2
+
+      expect(subject.GetCmndAliases2).to eq expected_aliases
+    end
+
+    it "parses and set runas aliases" do
+      lines = [
+        { type: "Runas_Alias", name: "ALIAS1", rest: "user" },
+        { comment: "test\n", type: "Runas_Alias", name: "ALIAS2",
+          rest: "user1, user2,\tuser3" }
+      ]
+      mock_sudo(lines)
+
+      expected_aliases = [
+        { "c" => "", "name" => "ALIAS1", "mem" => ["user"] },
+        { "c" => "test\n", "name" => "ALIAS2",
+          "mem" => ["user1", "user2", "user3"] }
+      ]
+
+      subject.ReadSudoSettings2
+
+      expect(subject.GetRunAsAliases2).to eq expected_aliases
+    end
+
+    it "parses and set rules" do
+      lines = [
+        { type: "user1", name: "ALL", rest: "NOPASSWD: /usr/bin/su operator" },
+        { comment: "test\n", type: "user1", name: "ALL",
+          rest: "/bin/adduser, /bin/rmuser" }
+      ]
+      mock_sudo(lines)
+
+      expected_rules = [
+        { "user" => "user1", "host" => "ALL", "comment" => "",
+          "tag" => "NOPASSWD:", "commands" => ["/usr/bin/su operator"] },
+        { "user" => "user1", "host" => "ALL", "comment" => "test\n",
+          "commands" => ["/bin/adduser", "/bin/rmuser"] }
+      ]
+
+      subject.ReadSudoSettings2
+
+      expect(subject.GetRules).to eq expected_rules
+    end
+
+    it "parses and set rules with multiple tags" do
+      pending "it use just first tag"
+
+      lines = [
+        { type: "user1", name: "ALL", rest: "NOPASSWD:NOEXEC: /usr/bin/su operator" },
+      ]
+      mock_sudo(lines)
+
+      expected_rules = [
+        { "user" => "user1", "host" => "ALL", "comment" => "",
+          "tag" => "NOPASSWD:NOEXEC:", "commands" => ["/usr/bin/su operator"] },
+      ]
+
+      subject.ReadSudoSettings2
+
+      expect(subject.GetRules).to eq expected_rules
+    end
+
+    it "parses and set rules with associated tags" do
+      pending "it removes whole first command and keep wrong tag with rest"
+
+      lines = [
+        { type: "user1", name: "ALL", rest: "NOPASSWD: /usr/bin/su operator, PASSWD: /bin/test" },
+      ]
+      mock_sudo(lines)
+
+      expected_rules = [
+        { "user" => "user1", "host" => "ALL", "comment" => "",
+          # FIXME: not sure how here should look expected result as data structure is bad
+          "tag" => "NOPASSWD:", "commands" => ["/usr/bin/su operator", "PASSWD: /bin/test"] },
+      ]
+
+      subject.ReadSudoSettings2
+
+      expect(subject.GetRules).to eq expected_rules
+    end
+  end
+end

--- a/test/sudo_test.rb
+++ b/test/sudo_test.rb
@@ -189,5 +189,22 @@ describe Yast::Sudo do
 
       expect(subject.GetRules).to eq expected_rules
     end
+
+    it "parses and set rules with run as specified" do
+      lines = [
+        # (root, bin : operator, system) means can run as root or bin user or as operator or system group
+        { type: "user1", name: "ALL", rest: "NOPASSWD: (root, bin : operator, system) /bin/test" },
+      ]
+      mock_sudo(lines)
+
+      expected_rules = [
+        { "user" => "user1", "host" => "ALL", "comment" => "", "run_as" => "(root, bin : operator, system)",
+          "tag" => "NOPASSWD:", "commands" => ["/bin/test"] },
+      ]
+
+      subject.ReadSudoSettings2
+
+      expect(subject.GetRules).to eq expected_rules
+    end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,39 @@
+ENV["Y2DIR"] = File.expand_path("../src", __dir__)
+
+# localization agnostic tests
+ENV["LC_ALL"] = "en_US.utf-8"
+ENV["LANG"] = "en_US.utf-8"
+
+require "yast"
+require "yast/rspec"
+
+RSpec.configure do |config|
+  config.mock_with :rspec do |mocks|
+    # If you misremember a method name both in code and in tests,
+    # will save you.
+    # https://relishapp.com/rspec/rspec-mocks/v/3-0/docs/verifying-doubles/partial-doubles
+    #
+    # With graceful degradation for RSpec 2
+    mocks.verify_partial_doubles = true if mocks.respond_to?(:verify_partial_doubles=)
+  end
+end
+
+if ENV["COVERAGE"]
+  require "simplecov"
+  SimpleCov.start do
+    add_filter "/test/"
+  end
+
+  src_location = File.expand_path("../src", __dir__)
+  # track all ruby files under src
+  SimpleCov.track_files("#{src_location}/**/*.rb")
+
+  # use coveralls for on-line code coverage reporting at Travis CI
+  if ENV["TRAVIS"]
+    require "coveralls"
+    SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+      SimpleCov::Formatter::HTMLFormatter,
+      Coveralls::SimpleCov::Formatter
+    ]
+  end
+end


### PR DESCRIPTION
related trello: https://trello.com/c/Wj8zx82g/1781-8-yast-sudo-new-better-parser

Goal of this PBI is to document what is supported and what not. Add example sudoers file that can be used to testing its ability. Also adding unit test for parsing part. And improve three things:

1. write properly `@include` and `@includedir`
2. improve error report when write failed
3. stop when unsupported scenario is detected and inform user

### Screenshots

old error report when write failed:
![sudo_fail_old](https://user-images.githubusercontent.com/478871/95453850-e0a51d00-096b-11eb-91e3-44a9ba71035a.png)
new one with better error message:
![sudo_fail_new](https://user-images.githubusercontent.com/478871/95453868-e864c180-096b-11eb-8f36-518934df4587.png)
Unsupported multiple tags:
![sudo_unsupported](https://user-images.githubusercontent.com/478871/95474654-a779a680-0985-11eb-9851-e10aa009dcd8.png)
Unsupported digest:
![sudo_unsupported2](https://user-images.githubusercontent.com/478871/95474666-ad6f8780-0985-11eb-855a-15d9642681fc.png)
