### PR TITLE
Stop using File.exists? which no longer works in Ruby 3.2 (bsc#1206419)

### DIFF
--- a/package/yast2-sudo.changes
+++ b/package/yast2-sudo.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Mar  6 14:43:16 UTC 2023 - Martin Vidner <mvidner@suse.com>
+
+- Stop using File.exists? which no longer works in Ruby 3.2
+  (bsc#1206419)
+- 4.6.1
+
+-------------------------------------------------------------------
 Fri Mar 03 14:44:07 UTC 2023 - Ladislav Slezák <lslezak@suse.cz>
 
 - Bump version to 4.6.0 (bsc#1208913)

--- a/package/yast2-sudo.spec
+++ b/package/yast2-sudo.spec
@@ -18,7 +18,7 @@
 
 Name:           yast2-sudo
 Summary:        YaST2 - Sudo configuration
-Version:        4.6.0
+Version:        4.6.1
 Release:        0
 Url:            https://github.com/yast/yast-sudo
 Group:          System/YaST

--- a/src/modules/Sudo.rb
+++ b/src/modules/Sudo.rb
@@ -668,7 +668,7 @@ module Yast
       # Error message
       if !WriteSudoSettings2()
         msg = _("Cannot write settings.")
-        if ::File.exists?("/etc/sudoers.YaST2.new") # if file exists it is invalid syntax
+        if ::File.exist?("/etc/sudoers.YaST2.new") # if file exists it is invalid syntax
           res = SCR.Execute(path(".target.bash_output"), "/usr/sbin/visudo -cf /etc/sudoers.YaST2.new")
           msg += _("\nSyntax error in target file. See /etc/sudoers.YaST2.new.\nDetails: ") + res["stdout"]
         end


### PR DESCRIPTION
## Problem

Ruby 3.2 removed `File.exists?` which has been long deprecated in favor of `File.exist?`

Here it is used as part of writing the config (only if writing of the config file failed).

- https://trello.com/c/jRe5bWVE
- https://bugzilla.suse.com/show_bug.cgi?id=1206419


## Solution

Fix the method name

## Testing

Tested manually. Unit tests would be all mocked out.

`osc build -x libyui-ncurses16; osc chroot; cd mygit/.../yast-sudo; rake run`

Confirm that it may not work because you're not root, `OK` to write settings. "Internal Error" appears without this fix.

## Screenshots

N/A
